### PR TITLE
[RFR] Add programmatic configuration

### DIFF
--- a/app/scripts/app/Crud/component/controller/CreateController.js
+++ b/app/scripts/app/Crud/component/controller/CreateController.js
@@ -28,7 +28,7 @@ define([
             self = this;
 
         angular.forEach(this.data.fields, function(field){
-            object[field.name] = field.value;
+            object[field.getName()] = field.value;
         });
 
         this.CrudManager

--- a/app/scripts/app/Crud/component/controller/EditController.js
+++ b/app/scripts/app/Crud/component/controller/EditController.js
@@ -31,11 +31,11 @@ define([
 
         angular.forEach(this.data.fields, function(field){
             value = field.value;
-            if (field.type === 'date') {
-                value = self.$filter('date')(value, field.validation.format);
+            if (field.type() === 'date') {
+                value = self.$filter('date')(value, field.validation().format);
             }
 
-            object[field.name] = value;
+            object[field.getName()] = value;
         });
 
         this.CrudManager.updateOne(this.data.entityName, object).then(function() {

--- a/app/scripts/app/Crud/component/controller/ListController.js
+++ b/app/scripts/app/Crud/component/controller/ListController.js
@@ -24,22 +24,23 @@ define([], function() {
             self = this;
 
         // Get identifier field, and build columns array (with only the fields defined with `"list" : true`)
-        angular.forEach(entityConfig.fields, function(field) {
-            if(typeof(field.identifier) !== 'undefined') {
-                self.identifierField = field.name;
-            }
-            if(typeof(field.list) === 'undefined' || field.list !== true) {
+        angular.forEach(entityConfig.getFields(), function(field) {
+            if(!field.list()) {
                 return;
             }
 
+            if(field.identifier()) {
+                self.identifierField = field.getName();
+            }
+
             columns.push({
-                field: field.name,
-                label: field.label
+                field: field.getName(),
+                label: field.label()
             });
         });
 
 
-        this.$scope.entityLabel = entityConfig.label;
+        this.$scope.entityLabel = entityConfig.label();
         this.$scope.grid = {
             dimensions : [ columns.length, rawItems.length ],
             columns: columns,

--- a/app/scripts/app/Crud/component/service/CrudManager.js
+++ b/app/scripts/app/Crud/component/service/CrudManager.js
@@ -18,12 +18,12 @@ define([
      * @returns {promise} (list of fields (with their values if set) & the entity name, label & id-
      */
     CrudManager.prototype.getOne = function(entityName, entityId) {
-        if (!(entityName in config.entities)) {
+        if (!config.hasEntity(entityName)) {
             return this.$q.reject('Entity ' + entityName + ' not found.');
         }
 
-        var entityConfig = config.entities[entityName];
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        var entityConfig = config.getEntity(entityName);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
         this.Restangular.setFullResponse(true);  // To get also the headers
 
         // Get element data
@@ -32,22 +32,18 @@ define([
             .get()
             .then(function(response) {
 
-                var fields = entityConfig.fields,
+                var fields = entityConfig.getFields(),
                     entity = response.data;
 
                 angular.forEach(fields, function(field, index) {
-                    if(typeof(field.edition) === "undefined") {
-                        return;
-                    }
-
-                    if (typeof(entity[field.name]) !== "undefined") {
-                        fields[index].value = entity[field.name];
+                    if (!(field.getName() in entity)) {
+                        fields[index].value = entity[field.getName()];
                     }
                 });
 
                 return {
                     fields: fields,
-                    entityLabel: entityConfig.label,
+                    entityLabel: entityConfig.label(),
                     entityName: entityName,
                     entityId : entityId
                 };
@@ -74,17 +70,16 @@ define([
             }
         }
 
-
-        if (!(entityName in config.entities)) {
+        if (!config.hasEntity(entityName)) {
             return this.$q.reject('Entity ' + entityName + ' not found.');
         }
 
-        var entityConfig = config.entities[entityName],
-            fields = this.filterEditionFields(entityConfig.fields, filters);
+        var entityConfig = config.getEntity(entityName),
+            fields = this.filterEditionFields(entityConfig.getFields(), filters);
 
         return {
             fields: fields,
-            entityLabel: entityConfig.label,
+            entityLabel: entityConfig.label(),
             entityName: entityName
         };
     };
@@ -103,18 +98,18 @@ define([
 
         angular.forEach(fields, function(field){
             // the field is not an edition field - do nothing
-            if (typeof(field.edition) === 'undefined') {
+            if (!field.edition()) {
                 return;
             }
 
             // if we don't specify a restriction, get all the edition fields
             if (!filters.length) {
-                return this[field.name] = field;
+                return this[field.getName()] = field;
             }
 
             // restriction to specified types fields
-            if (filters.indexOf(field.edition) !== -1) {
-                return this[field.name] = field;
+            if (filters.indexOf(field.edition()) !== -1) {
+                return this[field.getName()] = field;
             }
 
         }, filteredFields);
@@ -127,16 +122,16 @@ define([
      * Post the data to the API to create the new object
      *
      * @param {String}  entityName  the name of the entity
-     * @param {Object}  entity           the entity's object
+     * @param {Object}  entity      the entity's object
      *
      * @returns {promise}  the new object
      */
     CrudManager.prototype.createOne = function (entityName, entity) {
-        if (!(entityName in config.entities)) {
+        if (!config.hasEntity(entityName)) {
             return this.$q.reject('Entity ' + entityName + ' not found.');
         }
 
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
         this.Restangular.setFullResponse(false);
 
         // Get element data
@@ -155,11 +150,11 @@ define([
      * @returns {promise} the updated object
      */
     CrudManager.prototype.updateOne = function(entityName, entity) {
-        if (!(entityName in config.entities)) {
+        if (!config.hasEntity(entityName)) {
             return this.$q.reject('Entity ' + entityName + ' not found.');
         }
 
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
 
         // Get element data
         return this.Restangular
@@ -178,7 +173,7 @@ define([
      * @returns {promise}
      */
     CrudManager.prototype.deleteOne = function(entityName, entityId) {
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
 
         return this.Restangular
             .one(entityName, entityId)
@@ -198,20 +193,21 @@ define([
     CrudManager.prototype.getAll = function (entityName, page) {
         page = (typeof(page) === 'undefined') ? 1 : parseInt(page);
 
-        if (!(entityName in config.entities)) {
+        if (!config.hasEntity(entityName)) {
             return this.$q.reject('Entity ' + entityName + ' not found.');
         }
 
-        var entityConfig = config.entities[entityName],
-            perPage = config.global.per_page || 30;
+        var entityConfig = config.getEntity(entityName),
+            pagination = entityConfig.pagination(),
+            perPage = entityConfig.perPage();
 
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
         this.Restangular.setFullResponse(true);  // To get also the headers
 
         // Get grid data
         return this.Restangular
             .all(entityName)
-            .getList({ page: page, per_page: perPage})
+            .getList(pagination ? { page: page, per_page: perPage} : null)
             .then(function (response) {
                 return {
                     entityName: entityName,

--- a/app/scripts/app/Crud/view/edit-attribute.html
+++ b/app/scripts/app/Crud/view/edit-attribute.html
@@ -1,37 +1,37 @@
-<label for="{{ field.name }}" class="col-sm-2 control-label">{{ field.label }}</label>
+<label for="{{ field.getName() }}" class="col-sm-2 control-label">{{ field.label() }}</label>
 
-<div ng-if="field.edition == 'editable'">
-    <div class="col-sm-10" ng-switch="field.type">
-        <input id="{{ field.name }}" class="form-control" ng-switch-when="text" type="text" ng-model="field.value" />
+<div ng-if="field.edition() == 'editable'">
+    <div class="col-sm-10" ng-switch="field.type()">
+        <input id="{{ field.getName() }}" class="form-control" ng-switch-when="text" type="text" ng-model="field.value" />
 
-        <input id="{{ field.name }}" class="form-control" ng-switch-when="email" type="email" ng-model="field.value" />
+        <input id="{{ field.getName() }}" class="form-control" ng-switch-when="email" type="email" ng-model="field.value" />
 
-        <input id="{{ field.name }}" class="form-control" ng-switch-when="number" type="number" ng-model="field.value" />
+        <input id="{{ field.getName() }}" class="form-control" ng-switch-when="number" type="number" ng-model="field.value" />
 
         <div class="input-group datepicker col-sm-4" ng-switch-when="date">
-            <input id="{{ field.name }}" class="form-control" type="text" datepicker-popup="{{ field.validation.format }}" ng-model="field.value" min-date="field.minDate" max-date="field.maxDate" ng-required="field.validation.required" is-open="editController.openDatepicker[name]" close-text="Close" />
+            <input id="{{ field.getName() }}" class="form-control" type="text" datepicker-popup="{{ field.validation().format }}" ng-model="field.value" min-date="field.minDate" max-date="field.maxDate" ng-required="field.validation().required" is-open="editController.openDatepicker[name]" close-text="Close" />
 
             <span class="input-group-btn">
                 <button type="button" class="btn btn-default" ng-click="editController.toggleDatePicker($event, name)"><i class="glyphicon glyphicon-calendar"></i></button>
               </span>
         </div>
 
-        <select id="{{ field.name }}" class="form-control" ng-switch-when="link" ng-model="field.value" ng-options="option as option for option in componentNames"></select>
+        <select id="{{ field.getName() }}" class="form-control" ng-switch-when="link" ng-model="field.value" ng-options="option as option for option in componentNames"></select>
 
-        <select id="{{ field.name }}" class="form-control" ng-switch-when="links" ng-model="field.value" multiple ng-multiple="true" ng-options="option as option for option in componentNames"></select>
+        <select id="{{ field.getName() }}" class="form-control" ng-switch-when="links" ng-model="field.value" multiple ng-multiple="true" ng-options="option as option for option in componentNames"></select>
 
-        <input id="{{ field.name }}" type="checkbox" class="form-control" ng-switch-when="boolean" ng-model="field.value" />
+        <input id="{{ field.getName() }}" type="checkbox" class="form-control" ng-switch-when="boolean" ng-model="field.value" />
 
-        <select id="{{ field.name }}" class="form-control" ng-switch-when="choice" ng-model="field.value" ng-options="option as option for option in field.choices"></select>
+        <select id="{{ field.getName() }}" class="form-control" ng-switch-when="choice" ng-model="field.value" ng-options="option as option for option in field.choices"></select>
 
-        <select id="{{ field.name }}" class="form-control" ng-switch-when="choices" ng-model="field.value" multiple ng-multiple="{{ field.multiple }}" ng-options="option as option for option in field.choices"></select>
+        <select id="{{ field.getName() }}" class="form-control" ng-switch-when="choices" ng-model="field.value" multiple ng-multiple="{{ field.multiple }}" ng-options="option as option for option in field.choices"></select>
     </div>
 </div>
 
-<div ng-if="field.edition == 'read-only'">
-    <div class="col-sm-10 read-only" ng-switch="field.type">
+<div ng-if="field.edition() == 'read-only'">
+    <div class="col-sm-10 read-only" ng-switch="field.type()">
         <p ng-switch-when="text">{{ field.value }}</p>
 
-        <p ng-switch-when="integer">{{ field.value }}</p>
+        <p ng-switch-when="number">{{ field.value }}</p>
     </div>
 </div>

--- a/app/scripts/app/Main/component/controller/DashboardController.js
+++ b/app/scripts/app/Main/component/controller/DashboardController.js
@@ -25,23 +25,23 @@ define([], function() {
                     identifierField = 'id';
 
                 // Get identifier field, and build columns array (only field defined with `"list" : true` in config file)
-                angular.forEach(entityConfig.fields, function(field) {
-
-                    if(typeof(field.identifier) !== 'undefined') {
-                        identifierField = field.name;
-                    }
-                    if(typeof(field.dashboard) === 'undefined' || field.dashboard !== true) {
+                angular.forEach(entityConfig.getFields(), function(field) {
+                    if(!field.dashboard()) {
                         return;
                     }
 
+                    if(field.identifier()) {
+                        identifierField = field.getName();
+                    }
+
                     columns.push({
-                        field: field.name,
-                        label: field.label
+                        field: field.getName(),
+                        label: field.label()
                     });
                 });
 
                 self.$scope.panels[panel.entityName] = {
-                    label: panel.entityConfig.label,
+                    label: panel.entityConfig.label(),
                     columns: columns,
                     items: rawItems,
                     identifierField: identifierField,

--- a/app/scripts/app/Main/component/controller/SidebarController.js
+++ b/app/scripts/app/Main/component/controller/SidebarController.js
@@ -7,7 +7,7 @@ define([
         this.$scope = $scope;
         this.$location = $location;
 
-        this.entities = config.entities;
+        this.entities = config.getEntities();
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };

--- a/app/scripts/app/Main/component/service/PanelBuilder.js
+++ b/app/scripts/app/Main/component/service/PanelBuilder.js
@@ -17,17 +17,13 @@ define([
         var promises = [],
             self = this;
 
-        this.Restangular.setBaseUrl(config.global.baseApiUrl);
+        this.Restangular.setBaseUrl(config.baseApiUrl());
 
-        angular.forEach(Object.keys(config.entities) , function(entityName) {
+        angular.forEach(Object.keys(config.getEntities()) , function(entityName) {
 
             var deferred = self.$q.defer(),
-                entity = config.entities[entityName],
-                limit = entity.dashboard || 10;
-
-            if (typeof(entity.dashboard) === 'undefined') {
-                return;
-            }
+                entity = config.getEntity(entityName),
+                limit = entity.dashboard();
 
             // Get items
             self.Restangular

--- a/app/scripts/app/Main/view/layout.html
+++ b/app/scripts/app/Main/view/layout.html
@@ -10,7 +10,7 @@
             <ul class="nav" id="side-menu">
                 <li class="heading"><i class="fa fa-list-alt fa-fw"></i> Entities</li>
                 <li class="entities-repeat" ng-repeat="(key, entity) in sidebarController.entities">
-                    <a ng-click="sidebarController.displayList(key, $event)">{{entity.label}}</a>
+                    <a ng-click="sidebarController.displayList(key, $event)">{{ entity.label() }}</a>
                 </li>
             </ul>
         </div>

--- a/app/scripts/config-dist.js
+++ b/app/scripts/config-dist.js
@@ -1,67 +1,47 @@
-define([], function () {
+define([
+    'lib/config/Application',
+    'lib/config/Entity',
+    'lib/config/Field'
+], function (Application, Entity, Field) {
     "use strict";
 
-    return {
-        "global": {
-            "name": "Backend",
-            "baseApiUrl": "http://192.168.56.10:8080/"
-        },
-        "entities": {
-            "book" : {
-                "label": "Book",
-                "dashboard": 5,
-                "fields": [
-                    {
-                        "name": "id",
-                        "type": "integer",
-                        "label": "ID",
-                        "edition" : "read-only",
-                        "order": 1,
-                        "identifier" : true,
-                        "list": true,
-                        "dashboard": true,
-                        "validation": {}
-                    },
-                    {
-                        "name": "title",
-                        "type": "text",
-                        "label": "Title",
-                        "edition" : "editable",
-                        "order": 2,
-                        "list": true,
-                        "dashboard": true,
-                        "validation": {
-                            "required": true,
-                            "max-length" : 150
-                        }
-                    },
-                    {
-                        "name": "summary",
-                        "type": "text",
-                        "label": "Summary",
-                        "edition" : "editable",
-                        "order": 3,
-                        "dashboard" : false,
-                        "validation": {
-                            "required": true,
-                            "max-length" : 500
-                        }
-                    },
-                    {
-                        "name": "genre",
-                        "type": "text",
-                        "label": "Genre",
-                        "edition" : "editable",
-                        "order": 4,
-                        "dashboard" : false,
-                        "validation": {
-                            "required": true,
-                            "max-length" : 255
-                        }
-                    }
-
-                ]
-            }
-        }
-    };
+    return Application('My backend')
+        .baseApiUrl('http://localhost:3000/')
+        .addEntity(Entity('posts')
+            .label('Posts')
+            .dashboard(null)
+            .pagination(false)
+            .addField(Field('id')
+                .label('ID')
+                .type('number')
+                .identifier(true)
+                .edition('read-only')
+            )
+            .addField(Field('body')
+                .label('Body')
+                .edition('editable')
+                .validation({
+                    "required": true,
+                    "max-length" : 150
+                })
+            )
+        ).addEntity(Entity('comments')
+            .label('Comments')
+            .dashboard(null)
+            .pagination(false)
+            .addField(Field('id')
+                .label('ID')
+                .type('number')
+                .identifier(true)
+                .edition('read-only')
+            )
+            .addField(Field('body')
+                .label('Comment')
+                .edition('editable')
+                .validation({
+                    "required": true,
+                    "max-length" : 150
+                })
+            )
+        );
 });

--- a/app/scripts/lib/config/Application.js
+++ b/app/scripts/lib/config/Application.js
@@ -1,0 +1,57 @@
+define(['lib/config/Configurable'], function (Configurable) {
+    "use strict";
+
+    return function(title) {
+        var entities = {};
+
+        var config = {
+            title: title || "Backend",
+            baseApiUrl: "http://localhost:3000/"
+        };
+
+        function Application() {
+        }
+
+        /**
+         * Add an entity to the configuration
+         * @param {Entity} entity
+         */
+        Application.addEntity = function(entity) {
+            entities[entity.getName()] = entity;
+
+            return this;
+        };
+
+        /**
+         * Returns true if the application has the entity
+         * @param {String} name
+         * @returns {boolean}
+         */
+        Application.hasEntity = function(name) {
+            return name in entities;
+        };
+
+        /**
+         * Returns an Entity by it's name
+         *
+         * @param {String} name
+         * @returns {Entity}
+         */
+        Application.getEntity = function(name) {
+            return entities[name];
+        };
+
+        /**
+         * Returns all entities
+         *
+         * @returns {Object}
+         */
+        Application.getEntities = function() {
+            return entities;
+        };
+
+        Configurable(Application, config);
+
+        return Application;
+    };
+});

--- a/app/scripts/lib/config/Configurable.js
+++ b/app/scripts/lib/config/Configurable.js
@@ -1,0 +1,20 @@
+// @see: https://github.com/marmelab/gremlins.js/blob/master/src/utils/configurable.js
+
+define([], function () {
+    "use strict";
+
+    function configurable(targetFunction, config) {
+        for (var item in config) {
+            (function(item) {
+                targetFunction[item] = function(value) {
+                    if (!arguments.length) return config[item];
+                    config[item] = value;
+
+                    return targetFunction;
+                };
+            })(item); // for doesn't create a closure, forcing it
+        }
+    }
+
+    return configurable;
+});

--- a/app/scripts/lib/config/Entity.js
+++ b/app/scripts/lib/config/Entity.js
@@ -1,0 +1,54 @@
+define(['lib/config/Configurable'], function (Configurable) {
+    'use strict';
+
+    return function(entityName) {
+        var name = entityName || 'entity';
+        var fields = {};
+
+        var config = {
+            label: 'My entity',
+            dashboard: 5,
+            perPage: 30,
+            pagination: false
+        };
+
+        /**
+         *
+         * @constructor
+         */
+        function Entity() {
+        }
+
+        /**
+         * Object.name is protected, use a getter for it
+         *
+         * @returns {string}
+         */
+        Entity.getName = function() {
+            return name;
+        };
+
+        /**
+         * Add an field to the entity
+         * @param {Field} field
+         */
+        Entity.addField = function(field) {
+            fields[field.getName()] = field;
+
+            return this;
+        };
+
+        /**
+         * Returns all fields
+         *
+         * @returns {Object}
+         */
+        Entity.getFields = function() {
+            return fields;
+        };
+
+        Configurable(Entity, config);
+
+        return Entity;
+    }
+});

--- a/app/scripts/lib/config/Field.js
+++ b/app/scripts/lib/config/Field.js
@@ -1,0 +1,90 @@
+define(['lib/config/Configurable'], function (Configurable) {
+    'use strict';
+
+    return function(fieldName) {
+        var availableTypes = ['number', 'text', 'email', 'date'];
+        var availableEditions = ['read-only', 'editable'];
+        var name = fieldName || 'entity';
+        var value;
+
+        var config = {
+            type: 'text',
+            label: 'My field',
+            edition : 'editable',
+            order: 1,
+            identifier : false,
+            list: true,
+            dashboard: true,
+            validation: {}
+        };
+
+        /**
+         * @param {String} fieldName
+         * @constructor
+         */
+        function Field() {
+            this.value = null;
+        }
+
+        Configurable(Field, config);
+
+        /**
+         * Object.name is protected, use a getter for it
+         *
+         * @returns {string}
+         */
+        Field.getName = function() {
+            return name;
+        };
+
+        /**
+         * Set of get the type
+         *
+         * @param {String} type
+         * @returns string|Field
+         */
+        Field.type = function(type) {
+            if (arguments.length === 0) {
+                return config.type;
+            }
+
+            if (availableTypes.indexOf(type) === -1) {
+                throw new Exception('Type should be one of ' + availableTypes.join(', '));
+            }
+
+            config.type = type;
+
+            return this;
+        };
+
+        /**
+         *
+         * @param {String} edition
+         * @returns string|Field
+         */
+        Field.edition = function(edition) {
+            if (arguments.length === 0) {
+                return config.edition;
+            }
+
+            if (availableEditions.indexOf(edition) === -1) {
+                throw new Exception('Type should be one of ' + availableTypes.join(', '));
+            }
+
+            config.edition = edition;
+            return this;
+        };
+
+        Field.getValue = function() {
+            return value;
+        };
+
+        Field.setValue = function(v) {
+            value = v;
+
+            return this;
+        };
+
+        return Field;
+    }
+});

--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -5,7 +5,6 @@ $icon-font-path: "../app/scripts/bower_components/bootstrap-sass-official/vendor
 // endbower
 
 @import "sb-admin.scss";
-@import "spinner.scss";
 
 .nav > li.heading {
     position: relative;


### PR DESCRIPTION
ng-admin can now be configured like:

``` js
Application('My backend')
        .baseApiUrl('http://localhost:3000/')
        .addEntity(Entity('posts')
            .label('Posts')
            .dashboard(null)
            .pagination(false)
            .addField(Field('id')
                .label('ID')
                .type('number')
                .identifier(true)
                .edition('read-only')
            )
            .addField(Field('body')
                .label('Body')
                .edition('editable')
                .validation({
                    "required": true,
                    "max-length" : 150
                })
            )
        )
```
