### PR TITLE
Fixed typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ app.config(function(NgAdminConfigurationProvider, Application, Entity, Field, Re
         .addEntity(/* ... */)
 
     NgAdminConfigurationProvider.configure(app);
-}
+});
 ```
 
 Your application should use a `ui-view`:


### PR DESCRIPTION
In addition to the commit, one clarification: is the term _edition_, used in readme within text parts and code parts, intended? Or could that be something like:
- _Edit form_ when inside text 
- _editable_ when inside code 
