### PR TITLE
Exclude .map output files from clean: grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
         },
 
         clean : {
-            build : ["build/*", "!build/*.min.js", "!build/*.min.css"]
+            build : ["build/*", "!build/*.min.js", "!build/*.min.css", "!build/*.map"]
         },
 
         copy: {


### PR DESCRIPTION
We're compiling Sass files on Windows with `grunt-sass`, not with `grunt-contrib-sass` as originally present in Gruntfile. So we're not 100% sure on what happens with original build file, but we noticed 2 things:
1. ng-admin index page shows errors in console as it's looking for the map file
2. the grunt file, while building, runs a clean task that removes all files in `build\` apart from minimised JS and CSS, thus deleting any MAP file possibly generated

That's why we thought it should be correct to preserve a MAP file during build.
