### PR TITLE
[RFR] Add a css class to datagrid headers to help style column width

### DIFF
--- a/src/javascripts/ng-admin/Crud/view/datagrid.html
+++ b/src/javascripts/ng-admin/Crud/view/datagrid.html
@@ -1,7 +1,7 @@
 <table class="grid table table-condensed table-hover table-striped">
     <thead>
         <tr>
-            <th ng-repeat="column in columns">
+            <th ng-repeat="column in columns" ng-class="'ng-admin-column-' + column.field.name()">
                 <a ng-click="datagrid.sort(column.field)">
                     <span class="glyphicon {{ sortDir === 'DESC' ? 'glyphicon-chevron-down': 'glyphicon-chevron-up' }}" ng-if="datagrid.isSorting(column.field)"></span>
 


### PR DESCRIPTION
Now the datagrid `<th>` tags all have a custom tag named after the field, e.g. "ng-admin-column-login". Very convenient to set column width in CSS without relying on column count.
