### PR TITLE
[RFR] Make Reference column link to related edit view by default

### DIFF
--- a/src/javascripts/ng-admin/Crud/component/directive/column/ReferenceColumn.js
+++ b/src/javascripts/ng-admin/Crud/component/directive/column/ReferenceColumn.js
@@ -5,14 +5,27 @@ define(function (require) {
 
     var referenceColumnView = require('text!../../../view/column/reference.html');
 
-    function ReferenceColumn() {
+    function ReferenceColumn($location, Configuration) {
         return {
             restrict: 'E',
-            template: referenceColumnView
+            template: referenceColumnView,
+            link: function ($scope) {
+                var field = $scope.column.field;
+                var referenceEntity = field.targetEntity().name();
+                var relatedEntity = Configuration().getEntity(referenceEntity);
+                $scope.hasRelatedAdmin = function() {
+                    if (!relatedEntity) return false;
+                    return relatedEntity.editionView().isEnabled();
+                };
+                $scope.gotoReference = function (entry) {
+                    var referenceId = entry.values[field.name()];
+                    $location.path('/edit/' + referenceEntity + '/' + referenceId);
+                };
+            }
         };
     }
 
-    ReferenceColumn.$inject = [];
+    ReferenceColumn.$inject = ['$location', 'NgAdminConfiguration'];
 
     return ReferenceColumn;
 });

--- a/src/javascripts/ng-admin/Crud/view/column/reference.html
+++ b/src/javascripts/ng-admin/Crud/view/column/reference.html
@@ -1,5 +1,5 @@
-<div ng-switch="column.field.isEditLink()" ng-init="value = entry.listValues[column.field.name()]">
-    <a ng-switch-when="true" ng-click="edit(entry)">{{ value }}</a>
+<div ng-switch="column.field.isEditLink() && hasRelatedAdmin()" ng-init="value = entry.listValues[column.field.name()]">
+    <a ng-switch-when="true" ng-click="gotoReference(entry)">{{ value }}</a>
 
     <span ng-switch-default>{{ value }}</span>
 </div>

--- a/src/javascripts/ng-admin/Main/component/service/config/Reference.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Reference.js
@@ -15,7 +15,7 @@ define(function (require) {
         label: 'My reference',
         targetEntity : null,
         targetField : null,
-        isEditLink: true,
+        isEditLink: null,
         validation: {
             required: false
         }
@@ -26,7 +26,7 @@ define(function (require) {
      */
     function Reference(fieldName) {
         Field.apply(this, arguments);
-
+        this.config.isEditLink = true; // because the Field constructor overrides the default
         this.referencedValue = null;
         this.entries = {};
         this.config.name = fieldName || 'reference';


### PR DESCRIPTION
``` js
        comment.listView()
            .title('Comments')
            .addField(new Reference('post_id')
                .label('Post title')
                .map(truncate)
                .targetEntity(post)
                .targetField(new Field('title'))
            )
```

renders like:

![image](https://cloud.githubusercontent.com/assets/99944/5180211/4c3559a0-7489-11e4-8bb1-1a102f15ee2c.png)
