### PR TITLE
[RFR] Fix ReferencedList scope

### DIFF
--- a/src/javascripts/ng-admin/Crud/form/edit-attribute.html
+++ b/src/javascripts/ng-admin/Crud/form/edit-attribute.html
@@ -24,7 +24,7 @@
 
         <reference-many-field ng-switch-when="ReferenceMany"></reference-many-field>
 
-        <datagrid ng-switch-when="ReferencedList" ng-init="columns=field.getGridColumns();entries=field.getEntries();name=field.getReferencedView().name()" with-pagination="false"></datagrid>
+        <datagrid ng-switch-when="ReferencedList" ng-init="view=field.getReferencedView();columns=field.getGridColumns();entries=field.getEntries();name=field.getReferencedView().name()" with-pagination="false"></datagrid>
 
         <wysiwyg-field ng-switch-when="wysiwyg"></wysiwyg-field>
 

--- a/src/javascripts/ng-admin/Crud/list/DatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/DatagridController.js
@@ -16,9 +16,12 @@ define(function () {
         var searchParams = this.$location.search();
         this.sortField = 'sortField' in searchParams ? searchParams.sortField : '';
         this.sortDir = 'sortDir' in searchParams ? searchParams.sortDir : '';
-        this.$scope.fields = this.$scope.view.getDisplayedFields();
-        this.$scope.listActions = this.$scope.view.listActions ? this.$scope.view.listActions() : false; // FIXME the embedded datagrid inside an edition view points to the parent EditView instead of the ListView
-        this.$scope.entity = this.$scope.view.getEntity();
+        $scope.$watch("view", function() {
+            var view = $scope.view;
+            $scope.fields = view.getDisplayedFields();
+            $scope.listActions = view.listActions();
+            $scope.entity = view.getEntity();
+        });
     }
 
     /**

--- a/src/javascripts/ng-admin/Crud/show/show.html
+++ b/src/javascripts/ng-admin/Crud/show/show.html
@@ -44,7 +44,7 @@
 
             <reference-many-column ng-switch-when="ReferenceMany"></reference-many-column>
 
-            <datagrid ng-switch-when="ReferencedList" ng-init="columns=field.getGridColumns();entries=field.getEntries();name=field.getReferencedView().name()" with-pagination="false"></datagrid>
+            <datagrid ng-switch-when="ReferencedList" ng-init="view=field.getReferencedView();columns=field.getGridColumns();entries=field.getEntries();name=field.getReferencedView().name()" with-pagination="false"></datagrid>
 
             <wysiwyg-column ng-switch-when="wysiwyg"></wysiwyg-column>
 


### PR DESCRIPTION
ReferencedList is currently **broken** on master (the datagrid uses the parent view instead of the correct show view). This is because the ng-init directive executes after the Datagrid controller.

Using isolated scope is the right way to fix it, except it's a long refactoring.
