### PR TITLE
[RFR] Avoid to call entire API collection for References in show view

### DIFF
--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -84,8 +84,8 @@ define(function (require) {
                     rawEntry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
-                        return RetrieveQueries.getReferencedValues(view);
+                    referencedValues: ['RetrieveQueries', 'view', 'rawEntry', function (RetrieveQueries, view, rawEntry) {
+                        return RetrieveQueries.getReferencedValues(view, [rawEntry.values]);
                     }],
                     referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
                         var sortField = $stateParams.sortField,


### PR DESCRIPTION
Calling `getReferencedValues` with 2 arguments enables the single call API mechanism.

Fixes #202
