### PR TITLE
[RFR] Don't transit pagination through datagrid

### DIFF
--- a/src/javascripts/ng-admin/Crud/column/maReferencedListColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maReferencedListColumn.js
@@ -17,8 +17,7 @@ define(function (require) {
              'entries="field.entries"' +
              'fields="field.getReferencedView().displayedFields"' +
              'entity="field.getReferencedView().entity"' +
-             'per-page="field.getReferencedView().perPage()"' +
-             'listActions="[]" infinite-pagination="false" with-pagination="false">' +
+             'listActions="[]">' +
 '</ma-datagrid>'
         };
     }

--- a/src/javascripts/ng-admin/Crud/list/Datagrid.html
+++ b/src/javascripts/ng-admin/Crud/list/Datagrid.html
@@ -25,11 +25,3 @@
         </tr>
     </tbody>
 </table>
-
-<ma-datagrid-pagination
-        entries="entries"
-        infinite="infinitePagination"
-        next-page="nextPage"
-        per-page="perPage"
-        total-items="{{ totalItems }}"
-        ></ma-datagrid-pagination>

--- a/src/javascripts/ng-admin/Crud/list/DatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/DatagridController.js
@@ -13,7 +13,6 @@ define(function () {
      */
     function DatagridController($scope, $location, $anchorScroll) {
         $scope.entity = $scope.entity();
-        $scope.entries = $scope.entries();
         this.$scope = $scope;
         this.$location = $location;
         this.$anchorScroll = $anchorScroll;

--- a/src/javascripts/ng-admin/Crud/list/DatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/DatagridController.js
@@ -13,6 +13,7 @@ define(function () {
      */
     function DatagridController($scope, $location, $anchorScroll) {
         $scope.entity = $scope.entity();
+        $scope.entries = $scope.entries();
         this.$scope = $scope;
         this.$location = $location;
         this.$anchorScroll = $anchorScroll;

--- a/src/javascripts/ng-admin/Crud/list/DatagridPagination.html
+++ b/src/javascripts/ng-admin/Crud/list/DatagridPagination.html
@@ -1,18 +1,12 @@
 <div ng-if="paginationCtrl.displayPagination">
-    <div class="grid-detail row pull-right">
-    <span class="total">
-        <strong>{{ paginationCtrl.offsetBegin }}</strong> - <strong>{{ paginationCtrl.offsetEnd }}</strong> on <strong>{{ paginationCtrl.totalItems }}</strong>
-    </span>
-        <ul class="pagination pagination-sm">
-            <li ng-class="{ disabled: paginationCtrl.currentPage == 1}">
-                <a href ng-click="paginationCtrl.setPage(paginationCtrl.currentPage - 1)">« Prev</a>
-            </li>
-            <li ng-repeat="n in paginationCtrl.range(1, paginationCtrl.nbPages)" ng-class="{active: n == paginationCtrl.currentPage}" ng-click="paginationCtrl.setPage(n)">
-                <a href>{{ n }}</a>
-            </li>
-            <li ng-class="{disabled: paginationCtrl.currentPage == paginationCtrl.nbPages}">
-                <a href ng-click="paginationCtrl.setPage(paginationCtrl.currentPage + 1)">Next »</a>
-            </li>
-        </ul>
+    <div class="grid-detail">
+        <span class="total">
+            <strong>{{ paginationCtrl.offsetBegin }}</strong> - <strong>{{ paginationCtrl.offsetEnd }}</strong> on <strong>{{ paginationCtrl.totalItems }}</strong>
+        </span>
+        <div class="btn-group btn-group-sm" role="group" aria-label="pagination">
+            <a href class="btn btn-default" ng-if="paginationCtrl.currentPage != 1" ng-click="paginationCtrl.setPage(paginationCtrl.currentPage - 1)">« Prev</a>
+            <a href class="btn btn-default" ng-if="paginationCtrl.nbPages > 1" ng-repeat="n in paginationCtrl.range(1, paginationCtrl.nbPages)" ng-class="{'active': n == paginationCtrl.currentPage}" ng-click="paginationCtrl.setPage(n)">{{ n }}</a>
+            <a href class="btn btn-default" ng-if="paginationCtrl.currentPage != paginationCtrl.nbPages" ng-click="paginationCtrl.setPage(paginationCtrl.currentPage + 1)">Next »</a>
+        </div>
     </div>
 </div>

--- a/src/javascripts/ng-admin/Crud/list/list.html
+++ b/src/javascripts/ng-admin/Crud/list/list.html
@@ -23,10 +23,16 @@
               entries="listController.entries"
               fields="::listController.fields"
               list-actions="::listController.listActions"
-              entity="::listController.entity"
-              next-page="listController.nextPageCallback"
-              per-page="listController.itemsPerPage"
-              total-items="{{ listController.totalItems }}"
-              infinite-pagination="listController.infinitePagination">
+              entity="::listController.entity">
     </ma-datagrid>
+</div>
+
+<div class="row">
+    <ma-datagrid-pagination
+            infinite="listController.infinitePagination"
+            next-page="listController.nextPageCallback"
+            per-page="listController.itemsPerPage"
+            total-items="{{ listController.totalItems }}">
+    </ma-datagrid-pagination>
+
 </div>

--- a/src/javascripts/ng-admin/Crud/list/maDatagrid.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagrid.js
@@ -12,7 +12,7 @@ define(function (require) {
             template: datagridView,
             scope: {
                 name: '@',
-                entries: '&',
+                entries: '=',
                 fields: '&',
                 listActions: '&',
                 entity: '&'

--- a/src/javascripts/ng-admin/Crud/list/maDatagrid.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagrid.js
@@ -12,14 +12,10 @@ define(function (require) {
             template: datagridView,
             scope: {
                 name: '@',
-                entries: '=',
+                entries: '&',
                 fields: '&',
                 listActions: '&',
-                entity: '&',
-                perPage: '=',
-                nextPage: '=',
-                totalItems: '@',
-                infinitePagination: '='
+                entity: '&'
             },
             controllerAs: 'datagrid',
             controller: DatagridController

--- a/src/javascripts/ng-admin/Crud/list/maDatagridPagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridPagination.js
@@ -11,7 +11,6 @@ define(function (require) {
         return {
             restrict: 'E',
             scope: {
-                entries: '=',
                 perPage: '=',
                 nextPage: '=',
                 totalItems: '@',

--- a/src/javascripts/test/unit/Crud/list/maDatagridSpec.js
+++ b/src/javascripts/test/unit/Crud/list/maDatagridSpec.js
@@ -54,11 +54,12 @@ define(function (require) {
         });
 
         it("should add list actions", function () {
-            var element = $compile(directiveUsage)(scope);
-
             scope.fields = [new Field('title')];
             scope.listActions = ['edit'];
             scope.entries = [new Entry()];
+
+            var element = $compile(directiveUsage)(scope);
+
             scope.$digest();
 
             expect(element[0].querySelector('thead th:nth-child(2)').innerHTML).toContain('Actions');
@@ -68,13 +69,14 @@ define(function (require) {
 
         it("should add columns", function () {
             var entry1 = new Entry(),
-                element = $compile(directiveUsage)(scope);
-            entry1.values.title = 'Small cat';
+                element;
 
+            entry1.values.title = 'Small cat';
             scope.fields = [new Field('title').type('text')];
             scope.entries = [entry1];
-            scope.$digest();
 
+            element  = $compile(directiveUsage)(scope);
+            scope.$digest();
 
             expect(element[0].querySelector('tbody tr td:nth-child(1) ma-column').nodeName).toContain('MA-COLUMN');
         });

--- a/src/sass/ng-admin.scss
+++ b/src/sass/ng-admin.scss
@@ -186,14 +186,10 @@ div.bottom-loader {
 }
 
 .grid-detail {
+    text-align: right;
+    margin-bottom: 20px;
     .total {
-        float: left;
-        display: inline-block;
-        margin: 25px 10px 0 0;
-    }
-
-    .pagination {
-        float: right;
+        padding-right: 10px;
     }
 }
 


### PR DESCRIPTION
We can simplify the datagrid code (and binding) by moving the pagination out.

Also, using one-way databinding for entries to save on memory.

Finally, the pagination markup can be simplified to use native bootstrap components.

![image](https://cloud.githubusercontent.com/assets/99944/5670563/60713b12-9781-11e4-9871-64c1eb396e22.png)
