### PR TITLE
retrieve identifiers before getSingleApiCall call

### DIFF
--- a/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
@@ -141,14 +141,13 @@ define(function (require) {
         for (i in references) {
             reference = references[i];
             referencedView = reference.getReferencedView();
+            identifiers = reference.getIdentifierValues(rawValues);
             singleCallFilters = reference.getSingleApiCall(identifiers);
 
             // Check if we should retrieve values with 1 or multiple requests
             if (singleCallFilters || !rawValues) {
                 calls.push(self.getRawValues(referencedView, 1, false, reference.getSortFieldName(), 'ASC', singleCallFilters));
             } else {
-                identifiers = reference.getIdentifierValues(rawValues);
-
                 for (k in identifiers) {
                     calls.push(self.getOne(referencedView, identifiers[k]));
                 }


### PR DESCRIPTION
Moved identifiers retrieval before calling `getSingleApiCall` on `getReferencedValues` method.

Screenshot demonstrating the problem:
![captura de tela 2015-01-07 as 22 44 50](https://cloud.githubusercontent.com/assets/130494/5656168/a8811a02-96bf-11e4-85d0-363fa812f097.png)