### PR TITLE
Update readme: dashboardView section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ Defines the API endpoint for a view. It can be a string or a function.
 
 ### dashboardView Settings
 
+The `dashboardView` also defines `sortField` and `sortDir` fields like the `listView`.
+
+* `limit(Number)`
+Set the number of items.
+
 * `order(Number)`
 Define the order of the Dashboard panel for this entity in the dashboard
 


### PR DESCRIPTION
* The `limit` field of the `dashboardView` is used in the example, but not listed in the documentation.
* Also it is not mentioned, that you can use `sortField` and `sortDir` fields on a `dashboardView` (Both are not part of the general view settings and the `dashboardView` is only described as an "another special view", so it's not clear that this fields form the `listView` can be used for an `dashboardView` too).