### PR TITLE
Add option to define the route on a `isDetailLink` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,10 @@ Define the position of the field in the view.
 Define the format for `date` type.
 
 * `isDetailLink(boolean)`
-Tell if the value is a link in the list view. Default to true for the identifier field, false otherwise. The link points to the edition view, except for read-only entities, where it points to the show view.
+Tell if the value is a link in the list view. Default to true for the identifier and references field, false otherwise. The link points to the edition view, except for read-only entities, where it points to the show view.
+
+* `detailLinkRoute(string)`
+Define the route for a link in the list view, i.e. `isDetailLink` is true. The default is `edit`, hence the link points to the edition view. The other option is `show` to point to the show view.
 
 * `choices([{value: '', label: ''}, ...])`
 Define array of choices for `choice` type. A choice has both a value and a label.

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Define the format for `date` type.
 Tell if the value is a link in the list view. Default to true for the identifier and references field, false otherwise. The link points to the edition view, except for read-only entities, where it points to the show view.
 
 * `detailLinkRoute(string)`
-Define the route for a link in the list view, i.e. `isDetailLink` is true. The default is `edit`, hence the link points to the edition view. The other option is `show` to point to the show view.
+Define the route for a link in the list view, i.e. `isDetailLink` of the field is true. The default is `edit`, hence the link points to the edition view. The other option is `show` to point to the show view.
 
 * `choices([{value: '', label: ''}, ...])`
 Define array of choices for `choice` type. A choice has both a value and a label.

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -90,7 +90,7 @@ var app = new Application('My Application')
 app.layout(myLayout);
 ```
 
-The original layout can be found in [../src/javascripts/ng-admin/Main/view/layout.html](src/javascripts/ng-admin/Main/view/layout.html).
+The original layout can be found in [src/javascripts/ng-admin/Main/view/layout.html](../src/javascripts/ng-admin/Main/view/layout.html).
 
 ## Customizing Error Messages
 

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -90,7 +90,7 @@ var app = new Application('My Application')
 app.layout(myLayout);
 ```
 
-The original layout can be found in [src/javascripts/ng-admin/Main/view/layout.html](src/javascripts/ng-admin/Main/view/layout.html).
+The original layout can be found in [../src/javascripts/ng-admin/Main/view/layout.html](src/javascripts/ng-admin/Main/view/layout.html).
 
 ## Customizing Error Messages
 

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -34,7 +34,7 @@ define(function (require) {
                 };
                 scope.gotoDetail = function () {
                     this.clearRouteParams();
-                    var route = scope.entity().isReadOnly ? 'show' : 'edit';
+                    var route = scope.entity().isReadOnly ? 'show' : scope.field.detailLinkRoute();
 
                     $location.path('/' + route + '/' + scope.entry.entityName + '/' + scope.entry.identifierValue);
                     $anchorScroll(0);
@@ -44,7 +44,7 @@ define(function (require) {
                     var referenceEntity = scope.field.targetEntity().name();
                     var relatedEntity = Configuration().getEntity(referenceEntity);
                     var referenceId = scope.entry.values[scope.field.name()];
-                    var route = relatedEntity.isReadOnly ? 'show' : 'edit';
+                    var route = relatedEntity.isReadOnly ? 'show' : scope.field.detailLinkRoute();
                     $location.path('/' + route + '/' + referenceEntity + '/' + referenceId);
                 };
                 scope.clearRouteParams = function () {

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -22,7 +22,7 @@ define(function (require) {
         format: 'yyyy-MM-dd',
         template: defaultValueTemplate,
         isDetailLink: false,
-        detailLinkRoute: '',
+        detailLinkRoute: 'edit',
         list: true,
         dashboard: true,
         validation: {
@@ -47,7 +47,6 @@ define(function (require) {
         this.config.name = fieldName || Math.random().toString(36).substring(7);
         this.config.label = utils.camelCase(this.config.name);
         this.config.isDetailLink = fieldName === 'id';
-        this.config.detailLinkRoute = 'edit';
         this.maps = [];
     }
 

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -22,6 +22,7 @@ define(function (require) {
         format: 'yyyy-MM-dd',
         template: defaultValueTemplate,
         isDetailLink: false,
+        detailLinkRoute: '',
         list: true,
         dashboard: true,
         validation: {
@@ -46,6 +47,7 @@ define(function (require) {
         this.config.name = fieldName || Math.random().toString(36).substring(7);
         this.config.label = utils.camelCase(this.config.name);
         this.config.isDetailLink = fieldName === 'id';
+        this.config.detailLinkRoute = 'edit';
         this.maps = [];
     }
 


### PR DESCRIPTION
By default the `isDetailLink` field is linked to the edition view (or to the show view, if it is linked to a read only entity). I think there a cases, where you don't want to jump form the list view to the edition view of a specific item. That's why I added the following:

`detailLinkRoute(string)`
Define the route for a link in the list view, i.e. `isDetailLink` is true. The default is `edit`, hence the link points to the edition view. The other option is `show` to point to the show view.


Let me know, if I should change or improve something.