### PR TITLE
Fix the sorting of ReferencedList fields in the showView.

### DIFF
--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -66,7 +66,7 @@ define(function (require) {
         $stateProvider
             .state('show', {
                 parent: 'main',
-                url: '/show/:entity/:id',
+                url: '/show/:entity/:id?sortField&sortDir',
                 controller: 'ShowController',
                 controllerAs: 'showController',
                 templateProvider: templateProvider('ShowView', showTemplate),


### PR DESCRIPTION
Fix the sorting of ReferencedList fields in the showView. #254 (commit bc7745e54b6a1308d3b753fd6a65364bcbc1cc3f) wasn't enough to really fix it. Now it's possible to sort the ReferencedList table by a column.