### PR TITLE
[RFR] Fallback to column for non-editable fields in form

### DIFF
--- a/src/javascripts/ng-admin/Crud/form/edit-attribute.html
+++ b/src/javascripts/ng-admin/Crud/form/edit-attribute.html
@@ -46,6 +46,8 @@
     </div>
 
     <div ng-if="!field.editable()" ng-class="field.getCssClasses(entry)||'col-sm-10'">
-        <p class="form-control-static">{{ entry.values[field.name()] }}</p>
+        <p class="form-control-static">
+            <ma-column field="::field" entry="::entry" entity="::entity"></ma-column>
+        </p>
     </div>
 </div>


### PR DESCRIPTION
Non-editable choices field, for instance, need to be displayed as label, not value. Same for date field, etc. So instead of displaying the raw value, the creation and edition form fallback to a column.