### PR TITLE
[RFR] Allow isEditLink to disable links on references

### DIFF
--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -31,8 +31,11 @@ define(function (require) {
                     return;
                 }
                 scope.isDetailLink = function() {
+                    if (scope.field.isDetailLink() === false) {
+                        return false;
+                    }
                     if (!scope.isReference) {
-                        return scope.field.isDetailLink();
+                        return true;
                     }
                     var referenceEntity = scope.field.targetEntity().name();
                     var relatedEntity = Configuration().getEntity(referenceEntity);


### PR DESCRIPTION
Fixes:

```js
new Reference('fuel_type_id')
  .label('Fuel type')
  .targetEntity(fuel_type)
  .isDetailLink(false)
  .targetField(new Field('name')) // didn't work
```

refs #144