### PR TITLE
[RFR] Strip restangular methods from entries

### DIFF
--- a/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
@@ -24,10 +24,12 @@ define(function (require) {
      * @returns {promise} (list of fields (with their values if set) & the entity name, label & id-
      */
     RetrieveQueries.prototype.getOne = function (view, entityId) {
-        return this.Restangular
+        var Restangular = this.Restangular;
+        return Restangular
             .oneUrl(view.entity.name(), this.config.getRouteFor(view, entityId))
             .get()
             .then(function (response) {
+                response.data = Restangular.stripRestangular(response.data);
                 return view.mapEntry(response.data);
             });
     };
@@ -113,9 +115,14 @@ define(function (require) {
         }
 
         // Get grid data
-        return this.Restangular
+        var Restangular = this.Restangular;
+        return Restangular
             .allUrl(listView.entity.name(), this.config.getRouteFor(listView))
-            .getList(params);
+            .getList(params)
+            .then(function(response) {
+                response.data = Restangular.stripRestangular(response.data);
+                return response;
+            });
     };
 
     /**


### PR DESCRIPTION
Angular [adds its own method to every entity fetched](https://github.com/mgonto/restangular/blob/91be8642f21dcc275454d986b4cf8570366b84bd/src/restangular.js#L1062). As they are not namespaced, this has side effects.

I removed them, but I'm not sure we don't use them. @manuquentin, any insight?

Fixes #273 