### PR TITLE
[RFR] Include bind polyfill

### DIFF
--- a/src/javascripts/ng-admin.js
+++ b/src/javascripts/ng-admin.js
@@ -23,6 +23,7 @@ require.config({
         'nprogress': 'bower_components/nprogress/nprogress',
         'textangular': 'bower_components/textAngular/dist/textAngular.min',
         'angular-ui-codemirror': 'bower_components/angular-ui-codemirror/ui-codemirror.min',
+        'polyfill-bind': 'ng-admin/lib/polyfill/bind',
         'MainModule': 'ng-admin/Main/MainModule',
         'CrudModule': 'ng-admin/Crud/CrudModule'
     },
@@ -46,6 +47,7 @@ define(function (require) {
     'use strict';
 
     var angular = require('angular');
+    require('polyfill-bind');
     require('MainModule');
     require('CrudModule');
 


### PR DESCRIPTION
[bind polyfill](https://github.com/marmelab/ng-admin/blob/fcb7666f1a93f0321ccfd2d86cdf0711082d0ce5/src/javascripts/test/karma.conf.js#L22) is included in test because travis runs PhantomJS that doesn't implement it.

ng-admin should be compatible with [browsers that don't support `bind`](http://caniuse.com/#search=bind), it should be included in the minified build.