### PR TITLE
Compile description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The title of the view. ng-admin sees it as a template, and compiles it with the 
         editionView.title('Edit item "{{ entry.values.title }}"');
 
 * `description(String)`
-A text displayed below the title.
+A text displayed below the title. Like the `title` ng-admin sees it as a template and it can be customized in the same way.
 
 * `actions(String|Array)`
 Customize the list of actions for this view. You can pass a list of button names among 'back', 'list', 'show', create', 'edit', 'delete':

--- a/src/javascripts/ng-admin/Crud/delete/delete.html
+++ b/src/javascripts/ng-admin/Crud/delete/delete.html
@@ -8,7 +8,7 @@
             <h1 compile="deleteController.title">
                 Delete {{ deleteController.view.entity.name() | humanize:true | singularize }}  #{{ entry.identifierValue }}
             </h1>
-            <p class="lead" ng-if="deleteController.description">{{ deleteController.description }}</p>
+            <p class="lead" ng-if="deleteController.description" compile="deleteController.description">{{ deleteController.description }}</p>
         </div>
     </div>
 </div>

--- a/src/javascripts/ng-admin/Crud/form/create.html
+++ b/src/javascripts/ng-admin/Crud/form/create.html
@@ -8,7 +8,7 @@
             <h1 compile="formController.title">
                 Create new {{ formController.view.entity.name() | humanize:true | singularize }}
             </h1>
-            <p class="lead" ng-if="formController.description">{{ formController.description }}</p>
+            <p class="lead" ng-if="formController.description" compile="formController.description">{{ formController.description }}</p>
         </div>
     </div>
 </div>

--- a/src/javascripts/ng-admin/Crud/form/edit.html
+++ b/src/javascripts/ng-admin/Crud/form/edit.html
@@ -9,7 +9,7 @@
             <h1 compile="formController.title">
                 Edit {{ formController.entity.name() | humanize:true | singularize }}  #{{ entry.identifierValue }}
             </h1>
-            <p class="lead" ng-if="formController.description">{{ formController.description }}</p>
+            <p class="lead" ng-if="formController.description" compile="formController.description">{{ formController.description }}</p>
         </div>
     </div>
 </div>

--- a/src/javascripts/ng-admin/Crud/list/list.html
+++ b/src/javascripts/ng-admin/Crud/list/list.html
@@ -8,7 +8,7 @@
             <h1 compile="listController.title">
                 {{ listController.view.entity.name() | humanize | pluralize }} list
             </h1>
-            <p class="lead" ng-if="listController.description">{{ listController.description }}</p>
+            <p class="lead" ng-if="listController.description" compile="listController.description">{{ listController.description }}</p>
         </div>
 
         <ma-filter ng-if="listController.hasFilters" filters="::listController.filters"></ma-filter>

--- a/src/javascripts/ng-admin/Crud/show/show.html
+++ b/src/javascripts/ng-admin/Crud/show/show.html
@@ -10,7 +10,7 @@
             <h1 compile="showController.title">
                 {{ showController.view.entity.name() | humanize:true | singularize }}  #{{ entry.identifierValue }} Detail
             </h1>
-            <p class="lead" ng-if="showController.description">{{ showController.description }}</p>
+            <p class="lead" ng-if="showController.description" compile="showController.description">{{ showController.description }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Compile the `description` like the `title`. That means you can customize both with details from the current entry.

For instance you could display the ID of an entry in the `title` and the name in the `description`, because the names are too long for a big heading. Or you want to display some other extra information about the entry in the description.