### PR TITLE
[RFR] Introducing Factory methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,23 @@ var app = angular.module('myApp', ['ng-admin']);
 
 Configure ng-admin:
 ```js
-app.config(function (NgAdminConfigurationProvider, Application, Entity, Field, Reference, ReferencedList, ReferenceMany) {
+app.config(function (NgAdminConfigurationProvider) {
+    var nga = NgAdminConfigurationProvider;
     // set the main API endpoint for this admin
-    var app = new Application('My backend')
+    var app = nga.application('My backend')
         .baseApiUrl('http://localhost:3000/');
 
     // define an entity mapped by the http://localhost:3000/posts endpoint
-    var post = app.addEntity('posts');
+    var post = nga.entity'posts');
+    app.addEntity(post);
 
     // set the list of fields to map in each post view
-    post.dashboardView().addField(/* see example below */);
-    post.listView().addField(/* see example below */);
-    post.creationView().addField(/* see example below */);
-    post.editionView().addField(/* see example below */);
-    
-    NgAdminConfigurationProvider.configure(app);
+    post.dashboardView().fields(/* see example below */);
+    post.listView().fields(/* see example below */);
+    post.creationView().fields(/* see example below */);
+    post.editionView().fields(/* see example below */);
+
+    nga.configure(app);
 });
 ```
 
@@ -75,14 +77,14 @@ Here is a full example for a backend that will let you create, update, and delet
 
 var app = angular.module('myApp', ['ng-admin']);
 
-app.config(function (NgAdminConfigurationProvider, Application, Entity, Field, Reference, ReferencedList, ReferenceMany) {
-
-    var app = new Application('ng-admin backend demo') // application main title
+app.config(function (NgAdminConfigurationProvider) {
+    var nga = NgAdminConfigurationProvider;
+    var app = nga.application('ng-admin backend demo') // application main title
         .baseApiUrl('http://localhost:3000/'); // main API endpoint
 
     // define all entities at the top to allow references between them
-    var post = new Entity('posts') // the API endpoint for posts will be http://localhost:3000/posts/:id
-        .identifier(new Field('id')); // you can optionally customize the identifier used in the api ('id' by default)
+    var post = nga.entity('posts') // the API endpoint for posts will be http://localhost:3000/posts/:id
+        .identifier(nga.field('id')); // you can optionally customize the identifier used in the api ('id' by default)
 
     // set the application entities
     app.addEntity(post);
@@ -96,31 +98,31 @@ app.config(function (NgAdminConfigurationProvider, Application, Entity, Field, R
         .title('Recent posts')
         .order(1) // display the post panel first in the dashboard
         .limit(5) // limit the panel to the 5 latest posts
-        .fields([new Field('title').isDetailLink(true).map(truncate)]); // fields() called with arguments add fields to the view
+        .fields([nga.field('title').isDetailLink(true).map(truncate)]); // fields() called with arguments add fields to the view
 
     post.listView()
         .title('All posts') // default title is "[Entity_name] list"
         .description('List of posts with infinite pagination') // description appears under the title
         .infinitePagination(true) // load pages as the user scrolls
         .fields([
-            new Field('id').label('ID'), // The default displayed name is the camelCase field name. label() overrides id
-            new Field('title'), // the default list field type is "string", and displays as a string
-            new Field('published_at').type('date'), // Date field type allows date formatting
-            new Field('views').type('number'),
-            new ReferenceMany('tags') // a Reference is a particular type of field that references another entity
+            nga.field('id').label('ID'), // The default displayed name is the camelCase field name. label() overrides id
+            nga.field('title'), // the default list field type is "string", and displays as a string
+            nga.field('published_at', 'date'), // Date field type allows date formatting
+            nga.field('views', 'number'),
+            nga.field('tags', 'reference_many') // a Reference is a particular type of field that references another entity
                 .targetEntity(tag) // the tag entity is defined later in this file
-                .targetField(new Field('name')) // the field to be displayed in this list
+                .targetField(nga.field('name')) // the field to be displayed in this list
         ])
         .listActions(['show', 'edit', 'delete']);
 
     post.creationView()
         .fields([
-            new Field('title') // the default edit field type is "string", and displays as a text input
+            nga.field('title') // the default edit field type is "string", and displays as a text input
                 .attributes({ placeholder: 'the post title' }) // you can add custom attributes, too
                 .validation({ required: true, minlength: 3, maxlength: 100 }), // add validation rules for fields
-            new Field('teaser').type('text'), // text field type translates to a textarea
-            new Field('body').type('wysiwyg'), // overriding the type allows rich text editing for the body
-            new Field('published_at').type('date') // Date field type translates to a datepicker
+            nga.field('teaser', 'text'), // text field type translates to a textarea
+            nga.field('body', 'wysiwyg'), // overriding the type allows rich text editing for the body
+            nga.field('published_at', 'date') // Date field type translates to a datepicker
         ]);
 
     post.editionView()
@@ -128,32 +130,30 @@ app.config(function (NgAdminConfigurationProvider, Application, Entity, Field, R
         .actions(['list', 'show', 'delete']) // choose which buttons appear in the top action bar. Show is disabled by default
         .fields([
             post.creationView().fields(), // fields() without arguments returns the list of fields. That way you can reuse fields from another view to avoid repetition
-            new ReferenceMany('tags') // ReferenceMany translates to a select multiple
+            nga.field('tags', 'reference_many') // reference_many translates to a select multiple
                 .targetEntity(tag)
-                .targetField(new Field('name'))
+                .targetField(nga.field('name'))
                 .cssClasses('col-sm-4'), // customize look and feel through CSS classes
-            new Field('views')
-                .type('number')
+            nga.field('views', 'number')
                 .cssClasses('col-sm-4'),
-            new ReferencedList('comments') // display list of related comments
+            nga.field('comments', 'referenced_list') // display list of related comments
                 .targetEntity(comment)
                 .targetReferenceField('post_id')
                 .targetFields([
-                    new Field('id'),
-                    new Field('body').label('Comment')
+                    nga.field('id'),
+                    nga.field('body').label('Comment')
                 ])
         ]);
 
     post.showView() // a showView displays one entry in full page - allows to display more data than in a a list
         .fields([
-            new Field('id'),
+            nga.field('id'),
             post.editionView().fields(), // reuse fields from another view in another order
-            new Field('custom_action')
-                .type('template')
+            nga.field('custom_action', 'template')
                 .template('<other-page-link></other-link-link>')
         ]);
 
-    NgAdminConfigurationProvider.configure(app);
+    nga.configure(app);
 });
 ```
 
@@ -165,32 +165,32 @@ Each entity maps to a different API endpoint. The name of the entity, defines th
 
 ```js
 // set the main API endpoint for this admin
-var app = new Application('My backend')
+var app = nga.application('My backend')
     .baseApiUrl('http://localhost:3000/');
 
 // define an entity mapped by the http://localhost:3000/posts endpoint
-var post = new Entity('posts');
+var post = nga.entity('posts');
 ```
 
 * `label()`
 Defines the name of the entity, as displayed on screen
 
-        var comment = new Entity('comments').label('Discussions');
+        var comment = nga.entity('comments').label('Discussions');
 
 * `readOnly()`
 A read-only entity doesn't allow access to the mutation views (editionView, creationView, deletionView). In addition, all links to the editionView are replaced by links to the showView.
 
-        var tag = new Entity('tags').readOnly();
+        var tag = nga.entity('tags').readOnly();
         
 * `baseURL()`
 Defines the base API endpoint for all views of this entity
 
-        var comment = new Entity('comments').baseURL('http://localhost:3001/');
+        var comment = nga.entity('comments').baseURL('http://localhost:3001/');
         
 * `url()`
 Defines the API endpoint for all views of this entity. It can be a string or a function.
 
-        var comment = new Entity('comments').url(function(view, entityId) {
+        var comment = nga.entity('comments').url(function(view, entityId) {
             return '/comments/' + view.name() + '/' + entityId; // Can be absolute or relative
         });
 
@@ -216,9 +216,9 @@ These settings are available on all views.
 Add fields to a view (columns to a list, or a form controls to a form). Each field maps a property in the API endpoint result.
 
         listView.fields([
-            new Field('first_name'),
-            new Field('last_name'),
-            new Field('age').type('number')
+            nga.field('first_name'),
+            nga.field('last_name'),
+            nga.field('age', 'number')
         ]);
 
 * `fields()` Retrieve the list of fields added to a view. The result can be added to another view, to avoid repetition.
@@ -295,9 +295,9 @@ Enable or disable lazy loading.
 Add filters to the list. Each field maps a property in the API endpoint result.
 
         listView.filters([
-            new Field('first_name'),
-            new Field('last_name'),
-            new Field('age').type('number')
+            nga.field('first_name'),
+            nga.field('last_name'),
+            nga.field('age', 'number')
         ]);
 
 * `listActions(String|Array)`
@@ -315,17 +315,10 @@ Alternately, if you pass a string, it is compiled just like an Angular template,
 
 A field is the representation of a property of an entity. 
 
-### Field Classes
-
-- `Field`: simple field (possible types: number, string, text, boolean, wysiwyg, email, date, choice, choices, json, file, template)
-- `Reference`: one-to-many association with another entity
-- `ReferencedList`: many-to-one association
-- `ReferenceMany`: many-to-many association
-
 ### General Field Settings
 
-* `type(string ['number'|'string'|'text'|'boolean'|'wysiwyg'|'email'|'date'|'choice'|'choices'|'json'|'file'|'template'])`
-Define the field type. Default type is 'string', so you can omit it.
+* `nga.field(name, type)`
+Create a new field of the given type. Default type is 'string', so you can omit it. Bundled types include `number`, `string`, `text`, `boolean`, `wysiwyg`, `email`, `date`, `choice`, `choices`, `json`, `file`, and `template`
 
 * `label(string label)`
 Define the label of the field. Defaults to the uppercased field name.
@@ -351,18 +344,16 @@ Define array of choices for `choice` type. A choice has both a value and a label
 * `map(function)`
 Define a custom function to transform the value. It receive the value and the corresponding entry. Works in list, edit views and references.
 
-        myView.addField(new Field('characters')
+        nga.field('characters')
             .map(function truncate(value, entry) {
                 return value + '(' + entry.values.subValue + ')';
-            })
-        );
+            });
 
     Multiple `map` can be defined for a field:
 
-        myView.addField(new Field('comment')
+        nga.field('comment')
             .map(stripTags)
-            .map(truncate)
-        );
+            .map(truncate);
 
 * `validation(object)`
 Tell how to validate the view
@@ -374,18 +365,15 @@ Tell how to validate the view
 * `attributes(object)`
 A list of attributes to be added to the corresponding field.
 
-        editionView.addField(new Field('title')
-            .attributes({ placeholder: 'fill me !'})
-        );
+        nga.field('title').attributes({ placeholder: 'fill me !'})
 
 * `cssClasses(String|Function)`
 A list of CSS classes to be added to the corresponding field. If you provide a function, it will receive the current entry as first argument, to allow dynamic classes according to values.
 
-        editionView.addField(new Field('title')
+        nga.field('title')
             .cssClasses(function(entry) {
-               return entry.values.needsAttention ? 'bg-warning' : '';
-            })
-        );
+                return entry.values.needsAttention ? 'bg-warning' : '';
+            });
 
 * `defaultValue(*)`
 Define the default value of the field in the creation form.
@@ -410,9 +398,10 @@ The `template` field type allows you to use any HTML tag, including custom direc
 Buttons linking to the related view for the given entry.
 
 ```js
-entity.listView()
-   //
-   .addField(new Field('actions').type('template').template('<ma-show-button entry="entry" entity="entity" size="xs"></ma-show-button>'));
+entity.listView().fields([
+    // ...
+    nga.field('actions', 'template').template('<ma-show-button entry="entry" entity="entity" size="xs"></ma-show-button>')
+]);
 ```
 
 * `<ma-create-button>`
@@ -435,14 +424,16 @@ var template = '<ma-edit-button entry="entry" entity="entity" size="xs">' +
                '</ma-edit-button>' +
                '<ma-delete-button entry="entry" entity="entity" size="xs">' +
                '</ma-delete-button>';
-listView.addField(new Field('actions').type('template').template(template));
+listView.fields([
+    nga.field('actions', 'template').template(template)
+]);
 ```
 
 ## Relationships
 
-### Reference
+### `reference` Field
 
-The `Reference` type also defines `label`, `order`, `map`, `list` & `validation` options like the `Field` type.
+The `reference` type also defines `label`, `order`, `map`, `list` & `validation` options like the `Field` type.
 
 * `targetEntity(Entity)`
 Define the referenced entity.
@@ -450,26 +441,28 @@ Define the referenced entity.
 * `targetLabel(string)`
 Define the target field name used to retrieve the label of the referenced element.
 
-        myView.addField(new Reference('post_id')
-            .label('Post title')
-            .map(truncate) // Allows to truncate values in the select
-            .targetEntity(post) // Select a target Entity
-            .targetField(new Field('title')) // Select a label Field
-        );
+        myView.fields([
+            nga.field('post_id', 'reference')
+                .label('Post title')
+                .map(truncate) // Allows to truncate values in the select
+                .targetEntity(post) // Select a target Entity
+                .targetField(nga.field('title')) // Select a label Field
+        ]);
         
 * `singleApiCall(function(entityIds) {}`
 Define a function that returns parameters for filtering API calls. You can use it if you API support filter for multiple values.
 
 		// Will call /posts?post_id[]=1&post_id[]=2&post_id%[]=5...
-		commentList.addField(new Reference('post_id').singleApiCall(function (postIds) {
-          return {
-            'post_id[]': postIds
-          };
-        })
+		commentList.fields([
+            nga.field('post_id', 'reference')
+                .singleApiCall(function (postIds) {
+                    return { 'post_id[]': postIds };
+                })
+        ]);
 
-### ReferencedList
+### `referenced_list` Field
 
-The `ReferencedList` type also defines `label`, `order`, `map`, `list` & `validation` options like the `Field` type.
+The `referenced_list` type also defines `label`, `order`, `map`, `list` & `validation` options like the `Field` type.
 
 * `targetEntity(Entity)`
 Define the referenced entity.
@@ -480,23 +473,23 @@ Define the field name used to link the referenced entity.
 * `targetFields(Array(Field))`
 Define an array of fields that will be displayed in the list of the form.
 
-        myEditionView.addField(new ReferencedList('comments') // Define a N-1 relationship with the comment entity
-            .label('Comments')
-            .targetEntity(comment) // Target the comment Entity
-            .targetReferenceField('post_id') // Each comment with post_id = post.id (the identifier) will be displayed
-            .targetFields([ // Display comment field to display
-                new Field('id').label('ID'),
-                new Field('body').label('Comment')
-            ])
-            )
-        );
+        myEditionView.fields([
+            nga.field('comments', 'referenced_list') // Define a N-1 relationship with the comment entity
+                .label('Comments')
+                .targetEntity(comment) // Target the comment Entity
+                .targetReferenceField('post_id') // Each comment with post_id = post.id (the identifier) will be displayed
+                .targetFields([ // Display comment field to display
+                    nga.field('id').label('ID'),
+                    nga.field('body').label('Comment')
+                ])
+        ]);
 
 * `perPage(integer)`
 Define the maximum number of elements fetched and displayed in the list
 
-### ReferenceMany
+### `reference_many` Field
 
-The `ReferenceMany` type also defines `label`, `order`, `map` & `validation` options like the `Field` type.
+The `reference_many` field type also defines `label`, `order`, `map` & `validation` options like the `Field` type.
 
 * `targetEntity(Entity)`
 Define the referenced entity.
@@ -504,22 +497,24 @@ Define the referenced entity.
 * `targetField(Field)`
 Define the field name used to link the referenced entity.
 
-        myView.addField(new ReferenceMany('tags')
-           .label('Tags')
-           .isEditLink(false)
-           .targetEntity(tag) // Targeted entity
-           .targetField(new Field('name')) // Label Field to display in the list
-        )
+        myView.fields([
+            nga.field('tags', 'reference_many')
+               .label('Tags')
+               .isEditLink(false)
+               .targetEntity(tag) // Targeted entity
+               .targetField(nga.field('name')) // Label Field to display in the list
+        ])
         
 * `singleApiCall(function(entityIds) {}`
 Define a function that returns parameters for filtering API calls. You can use it if you API support filter for multiple values.
 
 		// Will call /tags?tag_id[]=1&tag_id[]=2&tag_id%[]=5...
-		postList.addField(new ReferenceMany('tags').singleApiCall(function (tagIds) {
-          return {
-            'tag_id[]': tagIds
-          };
-        })
+		postList.fields([
+            nga.field('tags', 'reference_many')
+                .singleApiCall(function (tagIds) {
+                    return { 'tag_id[]': tagIds };
+                })
+        ]);
 
 ## Contributing
 

--- a/UPGRADE-0.6.md
+++ b/UPGRADE-0.6.md
@@ -1,0 +1,62 @@
+# Upgrade to 0.5
+
+## Factories
+
+The configuration API doesn't allow direct instanciation of entity or fields via `new` anymore. Instead, you have to use the factory functions provided by `NgAdminConfigurationProvider`:
+
+```js
+// replace
+app.config(function (NgAdminConfigurationProvider, Application, Entity, Field) {
+    var admin = new Application('my admin');
+    var post = new Entity('posts');
+    post.listView().fields([
+        new Field('title'),
+        new Field('published_at').type('date'),
+        new Field('body').type('wysiwyg')
+    ]);
+}
+
+// by
+app.config(function (NgAdminConfigurationProvider) {
+    var nga = NgAdminConfigurationProvider;
+    var admin = nga.application('my admin');
+    var post = nga.entity('posts');
+    post.listView().fields([
+        nga.field('title'),
+        nga.field('published_at', 'date'),
+        nga.field('body', 'wysiwyg')
+    ]);
+}
+```
+
+`nga.field()` takes two parameters (name and type); calling `.type()` on an existing field isn't supported anymore.
+
+And references are fields, too. Instead of `new Reference()`, `new ReferenceMany()`, and `new ReferencedList()`, use `nga.field(name, type)` with the type `reference`, `reference_many`, and `referenced_list`:
+
+```js
+// replace
+post.listView().fields([
+    new ReferenceMany('tags')
+        .targetEntity(tag) // the tag entity is defined later in this file
+        .targetField(nga.field('name'))
+]);
+comment.listView().fields([
+    new Reference('post_id')
+        .label('Post')
+        .targetEntity(post)
+        .targetField(nga.field('title').map(truncate))
+])
+
+// by
+post.listView().fields([
+    nga.field('tags', 'reference_many')
+        .targetEntity(tag) // the tag entity is defined later in this file
+        .targetField(nga.field('name'))
+]);
+comment.listView().fields([
+    nga.field('post_id', 'reference')
+        .label('Post')
+        .targetEntity(post)
+        .targetField(nga.field('title').map(truncate))
+])
+```

--- a/doc/API-mapping.md
+++ b/doc/API-mapping.md
@@ -11,15 +11,16 @@ That means you don't need to adapt your API to ng-admin; ng-admin can adapt to a
 Ng-admin expects that requests for a single entity return a JSON object with all the properties defined as fields. For instance, for the following definition:
 
 ```js
-var bookEntity = new Entity('books');
+var bookEntity = nga.entity('books');
 bookEntity.editionView()
-    .addField(new Field('name'))
-    .addField(new Reference('author_id')
-        .label('Author')
-        .targetEntity(author)
-        .targetField(new Field('name'))
-    )
-    .addField(new Field('publication_date').type('date'));
+    .fields([
+        nga.field('name'), 
+        nga.field('author_id', 'reference')
+            .label('Author')
+            .targetEntity(author)
+            .targetField(nga.field('name')),
+        nga.field('publication_date', 'date')
+    ]);
 ```
 
 ng-admin expects the `GET http://your.api.domain/books/12` route to return a JSON response with a single object, containing at least the following properties:
@@ -165,8 +166,10 @@ All filter fields are added as a serialized object passed as the value of the `_
 
 ```js
 myEntity.filterView()
-    .addField(new Field('q').label('').attributes({ placeholder: 'Full text' }))
-    .addField(new Field('tag'))
+    .fields([
+        nga.field('q').label('').attributes({ placeholder: 'Full text' }),
+        nga.field('tag')
+    ]);
 ```
 
 ...will lead to API calls formatted like the following:

--- a/doc/Custom-pages.md
+++ b/doc/Custom-pages.md
@@ -77,9 +77,8 @@ Now the new directive is ready to be used inside a ng-admin field of type 'templ
 ```js
 post.showView().fields([
     // ...
-    new Field('custom_action')
+    nga.field('custom_action', 'template')
         .label('')
-        .type('template')
         .template('<send-email post="entry"></send-email>')
 ]);
 ```

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -15,19 +15,21 @@ Don't hesitate to inspect the generated source to look for the right CSS selecto
 To ease theming, you can add a custom class to your fields in every view, using the `cssClasses()` method.
 
 ```js
-myEntity.listView()
-    .addField(new Field('title').cssClasses(['foo', 'bar']));
+myEntity.listView().fields([
+    nga.field('title').cssClasses(['foo', 'bar'])
+]);
 ```
 
 `cssClasses()` can optionally accept a function, to return a class depending on the current entry.
 
 ```js
-myEntity.listView()
-    .addField(new Field('title').cssClasses(function(entry) {
+myEntity.listView().fields([
+    nga.field('title').cssClasses(function(entry) {
         if (entry.values.publishDate >= Date.now()) {
             return 'bg-success';
         }
-    }));
+    })
+]);
 ```
 
 ## Customizing Directives Templates
@@ -37,7 +39,7 @@ Using Angular's [`$provide`](https://docs.angularjs.org/api/auto/service/$provid
 ```js
 var app = angular.module('myApp', ['ng-admin']);
 
-app.config(function(NgAdminConfigurationProvider, ..., $provide) {
+app.config(function(NgAdminConfigurationProvider, $provide) {
         // Override textarea template
         $provide.decorator('maTextFieldDirective', ['$delegate', function ($delegate) {
             // You can modify directly the template
@@ -60,7 +62,7 @@ For a given entity, each of the main views (`list`, `show`, `create`, `edit`, `d
 
 ```js
 var myTemplate = require('text!./path/to/list.html');
-var myEntity = new Entity('foo_endpoint');
+var myEntity = nga.entity('foo_endpoint');
 myEntity.listView().template(myTemplate);
 // continue myEntity configuration
 // ...
@@ -86,7 +88,7 @@ If, for any reason, you need to override the application layout (for instance to
 
 ```js
 var myLayout = require('text!./path/to/layout.html');
-var app = new Application('My Application') 
+var app = nga.application('My Application') 
 app.layout(myLayout);
 ```
 

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -4,7 +4,7 @@
 
     var app = angular.module('myApp', ['ng-admin']);
 
-    app.config(function (NgAdminConfigurationProvider, Application, RestangularProvider) {
+    app.config(function (NgAdminConfigurationProvider, RestangularProvider) {
 
         var nga = NgAdminConfigurationProvider;
 
@@ -40,7 +40,7 @@
             return { params: params };
         });
 
-        var admin = new Application('ng-admin backend demo') // application main title
+        var admin = nga.application('ng-admin backend demo') // application main title
             .baseApiUrl('http://localhost:3000/'); // main API endpoint
 
         // define all entities at the top to allow references between them

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -4,7 +4,9 @@
 
     var app = angular.module('myApp', ['ng-admin']);
 
-    app.config(function (NgAdminConfigurationProvider, Application, Entity, Field, Reference, ReferencedList, ReferenceMany, RestangularProvider) {
+    app.config(function (NgAdminConfigurationProvider, Application, Reference, ReferencedList, ReferenceMany, RestangularProvider) {
+
+        var nga = NgAdminConfigurationProvider;
 
         function truncate(value) {
             if (!value) {
@@ -42,13 +44,13 @@
             .baseApiUrl('http://localhost:3000/'); // main API endpoint
 
         // define all entities at the top to allow references between them
-        var post = new Entity('posts'); // the API endpoint for posts will be http://localhost:3000/posts/:id
+        var post = nga.entity('posts'); // the API endpoint for posts will be http://localhost:3000/posts/:id
 
-        var comment = new Entity('comments')
+        var comment = nga.entity('comments')
             .baseApiUrl('http://localhost:3000/') // The base API endpoint can be customized by entity
-            .identifier(new Field('id')); // you can optionally customize the identifier used in the api ('id' by default)
+            .identifier(nga.field('id')); // you can optionally customize the identifier used in the api ('id' by default)
 
-        var tag = new Entity('tags')
+        var tag = nga.entity('tags')
             .readOnly(); // a readOnly entity has disabled creation, edition, and deletion views
 
         // set the application entities
@@ -66,31 +68,31 @@
             .title('Recent posts')
             .order(1) // display the post panel first in the dashboard
             .limit(5) // limit the panel to the 5 latest posts
-            .fields([new Field('title').isDetailLink(true).map(truncate)]); // fields() called with arguments add fields to the view
+            .fields([nga.field('title').isDetailLink(true).map(truncate)]); // fields() called with arguments add fields to the view
 
         post.listView()
             .title('All posts') // default title is "[Entity_name] list"
             .description('List of posts with infinite pagination') // description appears under the title
             .infinitePagination(true) // load pages as the user scrolls
             .fields([
-                new Field('id').label('ID'), // The default displayed name is the camelCase field name. label() overrides id
-                new Field('title'), // the default list field type is "string", and displays as a string
-                new Field('published_at').type('date'), // Date field type allows date formatting
-                new Field('views').type('number'),
+                nga.field('id').label('ID'), // The default displayed name is the camelCase field name. label() overrides id
+                nga.field('title'), // the default list field type is "string", and displays as a string
+                nga.field('published_at', 'date'), // Date field type allows date formatting
+                nga.field('views', 'number'),
                 new ReferenceMany('tags') // a Reference is a particular type of field that references another entity
                     .targetEntity(tag) // the tag entity is defined later in this file
-                    .targetField(new Field('name')) // the field to be displayed in this list
+                    .targetField(nga.field('name')) // the field to be displayed in this list
             ])
             .listActions(['show', 'edit', 'delete']);
 
         post.creationView()
             .fields([
-                new Field('title') // the default edit field type is "string", and displays as a text input
+                nga.field('title') // the default edit field type is "string", and displays as a text input
                     .attributes({ placeholder: 'the post title' }) // you can add custom attributes, too
                     .validation({ required: true, minlength: 3, maxlength: 100 }), // add validation rules for fields
-                new Field('teaser').type('text'), // text field type translates to a textarea
-                new Field('body').type('wysiwyg'), // overriding the type allows rich text editing for the body
-                new Field('published_at').type('date') // Date field type translates to a datepicker
+                nga.field('teaser', 'text'), // text field type translates to a textarea
+                nga.field('body', 'wysiwyg'), // overriding the type allows rich text editing for the body
+                nga.field('published_at', 'date') // Date field type translates to a datepicker
             ]);
 
         post.editionView()
@@ -100,28 +102,25 @@
                 post.creationView().fields(), // fields() without arguments returns the list of fields. That way you can reuse fields from another view to avoid repetition
                 new ReferenceMany('tags') // ReferenceMany translates to a select multiple
                     .targetEntity(tag)
-                    .targetField(new Field('name'))
+                    .targetField(nga.field('name'))
                     .cssClasses('col-sm-4'), // customize look and feel through CSS classes
-                new Field('pictures')
-                    .type('json'),
-                new Field('views')
-                    .type('number')
+                nga.field('pictures', 'json'),
+                nga.field('views', 'number')
                     .cssClasses('col-sm-4'),
                 new ReferencedList('comments') // display list of related comments
                     .targetEntity(comment)
                     .targetReferenceField('post_id')
                     .targetFields([
-                        new Field('id'),
-                        new Field('body').label('Comment')
+                        nga.field('id'),
+                        nga.field('body').label('Comment')
                     ])
             ]);
 
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list
             .fields([
-                new Field('id'),
+                nga.field('id'),
                 post.editionView().fields(), // reuse fields from another view in another order
-                new Field('custom_action')
-                    .type('template')
+                nga.field('custom_action', 'template')
                     .label('')
                     .template('<send-email post="entry"></send-email>')
             ]);
@@ -135,10 +134,9 @@
             .order(2) // display the comment panel second in the dashboard
             .limit(5)
             .fields([
-                new Field('id'),
-                new Field('body').label('Comment').map(truncate),
-                new Field() // template fields don't need a name in dashboard view
-                    .type('template') // a field which uses a custom template
+                nga.field('id'),
+                nga.field('body').label('Comment').map(truncate),
+                nga.field(null, 'template') // template fields don't need a name in dashboard view
                     .label('')
                     .template('<post-link entry="entry"></post-link>') // you can use custom directives, too
             ]);
@@ -147,27 +145,25 @@
             .title('Comments')
             .perPage(10) // limit the number of elements displayed per page. Default is 30.
             .fields([
-                new Field('created_at')
+                nga.field('created_at', 'date')
                     .label('Posted')
-                    .type('date')
                     .order(1),
-                new Field('body').map(truncate).order(3),
+                nga.field('body').map(truncate).order(3),
                 new Reference('post_id')
                     .label('Post')
                     .map(truncate)
                     .targetEntity(post)
-                    .targetField(new Field('title').map(truncate))
+                    .targetField(nga.field('title').map(truncate))
                     .order(4),
-                new Field('author').order(2)
+                nga.field('author').order(2)
             ])
             .filters([
-                new Field('q').type('string').label('').attributes({'placeholder': 'Global Search'}),
-                new Field('created_at')
+                nga.field('q', 'string').label('').attributes({'placeholder': 'Global Search'}),
+                nga.field('created_at', 'date')
                     .label('Posted')
-                    .type('date')
                     .attributes({'placeholder': 'Filter by date'})
                     .format('yyyy-MM-dd'),
-                new Field('today').type('boolean').map(function() {
+                nga.field('today', 'boolean').map(function() {
                     var now = new Date(),
                         year = now.getFullYear(),
                         month = now.getMonth() + 1,
@@ -181,29 +177,27 @@
                 new Reference('post_id')
                     .label('Post')
                     .targetEntity(post)
-                    .targetField(new Field('title'))    
+                    .targetField(nga.field('title'))    
             ])
             .listActions(['edit', 'delete']);
 
         comment.creationView()
             .fields([
-                new Field('created_at')
+                nga.field('created_at', 'date')
                     .label('Posted')
-                    .type('date')
                     .defaultValue(new Date()), // preset fields in creation view with defaultValue
-                new Field('author'),
-                new Field('body').type('wysiwyg'),
+                nga.field('author'),
+                nga.field('body', 'wysiwyg'),
                 new Reference('post_id')
                     .label('Post')
                     .map(truncate)
                     .targetEntity(post)
-                    .targetField(new Field('title')),
+                    .targetField(nga.field('title')),
             ]);
 
         comment.editionView()
             .fields(comment.creationView().fields())
-            .fields([new Field()
-                .type('template')
+            .fields([nga.field(null, 'template')
                 .label('')
                 .template('<post-link entry="entry"></post-link>') // template() can take a function or a string
             ]);
@@ -220,24 +214,23 @@
             .order(3)
             .limit(10)
             .fields([
-                new Field('id'),
-                new Field('name'),
-                new Field('published').label('Is published ?').type('boolean')
+                nga.field('id'),
+                nga.field('name'),
+                nga.field('published', 'boolean').label('Is published ?')
             ]);
 
         tag.listView()
             .infinitePagination(false) // by default, the list view uses infinite pagination. Set to false to use regulat pagination
             .fields([
-                new Field('id').label('ID'),
-                new Field('name'),
-                new Field('published').type('boolean').cssClasses(function(entry) { // add custom CSS classes to inputs and columns
+                nga.field('id').label('ID'),
+                nga.field('name'),
+                nga.field('published', 'boolean').cssClasses(function(entry) { // add custom CSS classes to inputs and columns
                     if (entry.values.published) {
                         return 'bg-success text-center';
                     }
                     return 'bg-warning text-center';
                 }),
-                new Field('custom')
-                    .type('template')
+                nga.field('custom', 'template')
                     .label('Upper name')
                     .template('{{ entry.values.name.toUpperCase() }}')
             ])
@@ -245,8 +238,8 @@
 
         tag.showView()
             .fields([
-                new Field('name'),
-                new Field('published').type('boolean')
+                nga.field('name'),
+                nga.field('published', 'boolean')
             ]);
 
         NgAdminConfigurationProvider.configure(admin);

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -4,7 +4,7 @@
 
     var app = angular.module('myApp', ['ng-admin']);
 
-    app.config(function (NgAdminConfigurationProvider, Application, Reference, ReferencedList, ReferenceMany, RestangularProvider) {
+    app.config(function (NgAdminConfigurationProvider, Application, RestangularProvider) {
 
         var nga = NgAdminConfigurationProvider;
 
@@ -79,7 +79,7 @@
                 nga.field('title'), // the default list field type is "string", and displays as a string
                 nga.field('published_at', 'date'), // Date field type allows date formatting
                 nga.field('views', 'number'),
-                new ReferenceMany('tags') // a Reference is a particular type of field that references another entity
+                nga.field('tags', 'reference_many') // a Reference is a particular type of field that references another entity
                     .targetEntity(tag) // the tag entity is defined later in this file
                     .targetField(nga.field('name')) // the field to be displayed in this list
             ])
@@ -100,14 +100,14 @@
             .actions(['list', 'show', 'delete']) // choose which buttons appear in the top action bar. Show is disabled by default
             .fields([
                 post.creationView().fields(), // fields() without arguments returns the list of fields. That way you can reuse fields from another view to avoid repetition
-                new ReferenceMany('tags') // ReferenceMany translates to a select multiple
+                nga.field('tags', 'reference_many') // ReferenceMany translates to a select multiple
                     .targetEntity(tag)
                     .targetField(nga.field('name'))
                     .cssClasses('col-sm-4'), // customize look and feel through CSS classes
                 nga.field('pictures', 'json'),
                 nga.field('views', 'number')
                     .cssClasses('col-sm-4'),
-                new ReferencedList('comments') // display list of related comments
+                nga.field('comments', 'referenced_list') // display list of related comments
                     .targetEntity(comment)
                     .targetReferenceField('post_id')
                     .targetFields([
@@ -149,7 +149,7 @@
                     .label('Posted')
                     .order(1),
                 nga.field('body').map(truncate).order(3),
-                new Reference('post_id')
+                nga.field('post_id', 'reference')
                     .label('Post')
                     .map(truncate)
                     .targetEntity(post)
@@ -174,7 +174,7 @@
                         created_at: [year, month, day].join('-') // ?created_at=... will be appended to the API call
                     };                    
                 }),
-                new Reference('post_id')
+                nga.field('post_id', 'reference')
                     .label('Post')
                     .targetEntity(post)
                     .targetField(nga.field('title'))    
@@ -188,7 +188,7 @@
                     .defaultValue(new Date()), // preset fields in creation view with defaultValue
                 nga.field('author'),
                 nga.field('body', 'wysiwyg'),
-                new Reference('post_id')
+                nga.field('post_id', 'reference')
                     .label('Post')
                     .map(truncate)
                     .targetEntity(post)

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -242,7 +242,7 @@
                 nga.field('published', 'boolean')
             ]);
 
-        NgAdminConfigurationProvider.configure(admin);
+        nga.configure(admin);
     });
 
     app.directive('postLink', ['$location', function ($location) {

--- a/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
+++ b/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
@@ -3,6 +3,7 @@
 define(function () {
     'use strict';
 
+    var Application = require('ng-admin/Main/component/service/config/Application');
     var Entity = require('ng-admin/Main/component/service/config/Entity');
     var Field = require('ng-admin/Main/component/service/config/Field');
     var Reference = require('ng-admin/Main/component/service/config/Reference');
@@ -22,6 +23,13 @@ define(function () {
         return function () {
             return config;
         };
+    };
+
+    /**
+     * @returns {Application}
+     */
+    NgAdminConfiguration.prototype.application = function(name) {
+        return new Application(name);
     };
 
     /**

--- a/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
+++ b/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
@@ -3,6 +3,9 @@
 define(function () {
     'use strict';
 
+    var Entity = require('ng-admin/Main/component/service/config/Entity');
+    var Field = require('ng-admin/Main/component/service/config/Field');
+
     function NgAdminConfiguration() {
         this.config = null;
     }
@@ -16,6 +19,24 @@ define(function () {
         return function () {
             return config;
         };
+    };
+
+    /**
+     * @returns {Entity}
+     */
+    NgAdminConfiguration.prototype.entity = function(name) {
+        return new Entity(name);
+    };
+
+    /**
+     * @returns {Field}
+     */
+    NgAdminConfiguration.prototype.field = function(name, type) {
+        var field = new Field(name);
+        if (type) {
+            field.type(type);
+        }
+        return field;
     };
 
     NgAdminConfiguration.$inject = [];

--- a/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
+++ b/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
@@ -5,6 +5,9 @@ define(function () {
 
     var Entity = require('ng-admin/Main/component/service/config/Entity');
     var Field = require('ng-admin/Main/component/service/config/Field');
+    var Reference = require('ng-admin/Main/component/service/config/Reference');
+    var ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany');
+    var ReferencedList = require('ng-admin/Main/component/service/config/ReferencedList');
 
     function NgAdminConfiguration() {
         this.config = null;
@@ -32,6 +35,15 @@ define(function () {
      * @returns {Field}
      */
     NgAdminConfiguration.prototype.field = function(name, type) {
+        if (type == 'reference') {
+            return new Reference(name);
+        }
+        if (type == 'reference_many') {
+            return new ReferenceMany(name);
+        }
+        if (type == 'referenced_list') {
+            return new ReferencedList(name);
+        }
         var field = new Field(name);
         if (type) {
             field.type(type);


### PR DESCRIPTION
Implements the first part of the changes proposed in #294. This PR is backwards compatible, meaning that using `new Field()` is still supported at this point.

I suggest we merge this one quickly to let users write configuration with factories as of now. Additional features (subclassing Field, overriding default fields) won't harm users who already use the factory syntax.