### PR TITLE
[BC Break][RFR] Specialize Configuration Field Classes

### DIFF
--- a/UPGRADE-0.6.md
+++ b/UPGRADE-0.6.md
@@ -31,9 +31,11 @@ app.config(function (NgAdminConfigurationProvider) {
 }
 ```
 
+The upgrade work is to replace `new Field('foo').type('bar')` by `nga.field('foo', 'bar')`. 
+
 `nga.field()` takes two parameters (name and type); calling `.type()` on an existing field isn't supported anymore.
 
-And references are fields, too. Instead of `new Reference()`, `new ReferenceMany()`, and `new ReferencedList()`, use `nga.field(name, type)` with the type `reference`, `reference_many`, and `referenced_list`:
+And references are fields, too. Instead of `new Reference()`, `new ReferenceMany()`, and `new ReferencedList()`, use `nga.field(name, type)` with the types `reference`, `reference_many`, and `referenced_list`:
 
 ```js
 // replace

--- a/UPGRADE-0.6.md
+++ b/UPGRADE-0.6.md
@@ -31,11 +31,9 @@ app.config(function (NgAdminConfigurationProvider) {
 }
 ```
 
-The upgrade work is to replace `new Field('foo').type('bar')` by `nga.field('foo', 'bar')`. 
-
 `nga.field()` takes two parameters (name and type); calling `.type()` on an existing field isn't supported anymore.
 
-And references are fields, too. Instead of `new Reference()`, `new ReferenceMany()`, and `new ReferencedList()`, use `nga.field(name, type)` with the types `reference`, `reference_many`, and `referenced_list`:
+And references are fields, too. Instead of `new Reference()`, `new ReferenceMany()`, and `new ReferencedList()`, use `nga.field(name, type)` with the type `reference`, `reference_many`, and `referenced_list`:
 
 ```js
 // replace

--- a/UPGRADE-0.7.md
+++ b/UPGRADE-0.7.md
@@ -1,0 +1,3 @@
+# Upgrade to 0.7
+
+ng-admin 0.7 breaks compatibility with 0.5 and makes the "factories" configuration API compulsory. If your configuration uses `nga.field()`, it will still work woth 0.7. If it uses `new Field()`, you'll need to follow [the 0.6 upgrade guide](https://github.com/marmelab/ng-admin/blob/b3c7b1afc6a52651df6ba4454d8461620339b4da/UPGRADE-0.6.md).

--- a/src/javascripts/ng-admin/Crud/column/maWysiwygColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maWysiwygColumn.js
@@ -3,17 +3,25 @@
 define(function (require) {
     'use strict';
 
-    function maWysiwygColumn() {
+    function maWysiwygColumn($filter) {
         return {
             restrict: 'E',
             scope: {
-                value: '&'
+                value: '&',
+                field: '&'
             },
-            template: '<span ng-bind-html="value()"></span>'
+            link: function(scope) {
+                var value = scope.value();
+                if (scope.field().stripTags()) {
+                    value = $filter('stripTags')(value);
+                }
+                scope.htmlValue = value;
+            },
+            template: '<span ng-bind-html="htmlValue"></span>'
         };
     }
 
-    maWysiwygColumn.$inject = [];
+    maWysiwygColumn.$inject = ['$filter'];
 
     return maWysiwygColumn;
 });

--- a/src/javascripts/ng-admin/Crud/field/maDateField.js
+++ b/src/javascripts/ng-admin/Crud/field/maDateField.js
@@ -18,6 +18,10 @@ define(function (require) {
             link: function(scope, element) {
                 var field = scope.field();
                 scope.name = field.name();
+                scope.rawValue = scope.value;
+                scope.$watch('rawValue', function(rawValue) {
+                    scope.value = field.parse()(rawValue);
+                });
                 scope.format = field.format();
                 scope.v = field.validation();
                 scope.isOpen = false;
@@ -34,7 +38,7 @@ define(function (require) {
             },
             template:
 '<div class="input-group datepicker">' +
-    '<input type="text" ng-model="value" id="{{ name }}" name="{{ name }}" class="form-control" ' +
+    '<input type="text" ng-model="rawValue" id="{{ name }}" name="{{ name }}" class="form-control" ' +
            'datepicker-popup="{{ format }}" is-open="isOpen" close-text="Close" ' +
            'ng-required="v.required" />' +
     '<span class="input-group-btn">' +

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -2,16 +2,12 @@ define(function(require) {
     "use strict";
 
     function getReadWidget() {
-        // special case: will cause recursion in listView if returning datagrid
-        return '';
-        /**
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}" ' +
                  'entries="field.entries" ' +
                  'fields="::field.getReferencedView().fields() | orderElement" ' +
                  'list-actions="::field.listActions()" ' +
                  'entity="::field.getReferencedView().entity">' +
             '</ma-datagrid>';
-        **/
     }
     function getLinkWidget() {
         return 'error: cannot display referenced_list field as linkable';

--- a/src/javascripts/ng-admin/Crud/fieldView/WysiwygFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/WysiwygFieldView.js
@@ -2,7 +2,7 @@ define(function(require) {
     "use strict";
 
     function getReadWidget() {
-        return '<ma-wysiwyg-column value="::entry.values[field.name()]|stripTags"></ma-wysiwyg-column>';
+        return '<ma-wysiwyg-column field="::field" value="::entry.values[field.name()]"></ma-wysiwyg-column>';
     }
     function getLinkWidget() {
         return 'error: cannot display wysiwyg field as linkable';

--- a/src/javascripts/ng-admin/Crud/filter/maFilterController.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilterController.js
@@ -41,10 +41,6 @@ define(function () {
 
             if (this.$scope.values[fieldName]) {
                 values[fieldName] = this.$scope.values[fieldName];
-
-                if (field.type() === 'date') {
-                    values[fieldName] = field.parse()(values[fieldName]);
-                }
             }
         }
 

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -50,10 +50,6 @@ define(function () {
         for (i in fields) {
             field = fields[i];
             value = entry.values[field.name()];
-            if (field.type() === 'date') {
-                value = field.parse()(value);
-            }
-
             object[field.name()] = value;
         }
 

--- a/src/javascripts/ng-admin/Main/MainModule.js
+++ b/src/javascripts/ng-admin/Main/MainModule.js
@@ -20,9 +20,6 @@ define(function (require) {
     MainModule.constant('Application', require('ng-admin/Main/component/service/config/Application'));
     MainModule.constant('Entity', require('ng-admin/Main/component/service/config/Entity'));
     MainModule.constant('Field', require('ng-admin/Main/component/service/config/Field'));
-    MainModule.constant('Reference', require('ng-admin/Main/component/service/config/Reference'));
-    MainModule.constant('ReferencedList', require('ng-admin/Main/component/service/config/ReferencedList'));
-    MainModule.constant('ReferenceMany', require('ng-admin/Main/component/service/config/ReferenceMany'));
 
     // Configuration view
     MainModule.constant('MenuView', require('ng-admin/Main/component/service/config/view/MenuView'));

--- a/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
+++ b/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
@@ -6,9 +6,6 @@ define(function (require) {
     var Application = require('ng-admin/Main/component/service/config/Application');
     var Entity = require('ng-admin/Main/component/service/config/Entity');
     var Field = require('ng-admin/Main/component/service/config/Field');
-    var Reference = require('ng-admin/Main/component/service/config/Reference');
-    var ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany');
-    var ReferencedList = require('ng-admin/Main/component/service/config/ReferencedList');
 
     function NgAdminConfiguration() {
         this.config = null;

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -7,10 +7,6 @@ define(function (require) {
         Configurable = require('ng-admin/Main/component/service/config/Configurable'),
         utils = require('ng-admin/lib/utils');
 
-    function defaultValueTemplate(entry) {
-        return '';
-    }
-
     var config = {
         name: 'myField',
         type: 'string',
@@ -18,7 +14,6 @@ define(function (require) {
         editable: true,
         order: null,
         identifier: false,
-        template: defaultValueTemplate,
         isDetailLink: false,
         detailLinkRoute: 'edit',
         list: true,
@@ -28,7 +23,6 @@ define(function (require) {
             minlength: 0,
             maxlength: 99999 // We can't remove ng-maxlength directive
         },
-        choices: [],
         defaultValue: null,
         attributes: {},
         cssClasses: '',
@@ -136,15 +130,6 @@ define(function (require) {
     };
 
     /**
-      * Return field value
-      *
-      * @returns mixed
-      */
-    Field.prototype.getTemplateValue = function (data) {
-        return typeof (this.config.template) === 'function' ? this.config.template(data) : this.config.template;
-    };
-
-    /**
      * @deprecated use Field.isDetailLink() instead
      */
     Field.prototype.isEditLink = function(bool) {
@@ -154,14 +139,6 @@ define(function (require) {
         }
         return this.isDetailLink(bool);
     }
-
-    /**
-     * only for type choice
-     */
-    Field.prototype.getLabelForChoice = function(value) {
-        var choice = this.choices().filter(function(choice) { return choice.value == value }).pop();
-        return choice ? choice.label : null;
-    };
 
     return Field;
 });

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -52,25 +52,9 @@ define(function (require) {
      * @returns {Field}
      */
     Field.prototype.map = function (fn) {
+        if (!arguments.length) return this.maps;
         this.maps.push(fn);
 
-        return this;
-    };
-
-    Field.prototype.validation = function (obj) {
-        if (!arguments.length) {
-            // getter
-            return this.config.validation;
-        }
-        // setter
-        for (var property in obj) {
-            if (!obj.hasOwnProperty(property)) continue;
-            if (obj[property] === null) {
-                delete this.config.validation[property];
-            } else {
-                this.config.validation[property] = obj[property];
-            }
-        }
         return this;
     };
 
@@ -94,17 +78,34 @@ define(function (require) {
         return value;
     };
 
+    Field.prototype.validation = function (obj) {
+        if (!arguments.length) {
+            // getter
+            return this.config.validation;
+        }
+        // setter
+        for (var property in obj) {
+            if (!obj.hasOwnProperty(property)) continue;
+            if (obj[property] === null) {
+                delete this.config.validation[property];
+            } else {
+                this.config.validation[property] = obj[property];
+            }
+        }
+        return this;
+    };
+
     /**
      * Get CSS classes list based on the `cssClasses` configuration
      *
      * @returns {string}
      */
     Field.prototype.getCssClasses = function (entry) {
+        if (this.config.cssClasses.constructor === Array) {
+            return this.config.cssClasses.join(' ');
+        }
         if (typeof this.config.cssClasses === 'function') {
             return this.config.cssClasses(entry);
-        }
-        if (typeof this.config.cssClasses.constructor === Array) {
-            return this.config.cssClasses.join(' ');
         }
         return this.config.cssClasses;
     };

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -18,10 +18,6 @@ define(function (require) {
         editable: true,
         order: null,
         identifier: false,
-        format: 'yyyy-MM-dd',
-        parse: function (date) {
-            return date;
-        },
         template: defaultValueTemplate,
         isDetailLink: false,
         detailLinkRoute: 'edit',

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -45,22 +45,6 @@ define(function (require) {
     Configurable(Field.prototype, config);
 
     /**
-     * Set or get the type
-     *
-     * @param {String} type
-     * @returns string|Field
-     */
-    Field.prototype.type = function (type) {
-        if (arguments.length === 0) {
-            return this.config.type;
-        }
-
-        this.config.type = type;
-
-        return this;
-    };
-
-    /**
      * Add a map function
      *
      * @param {Function} fn

--- a/src/javascripts/ng-admin/Main/component/service/config/Field.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Field.js
@@ -25,11 +25,7 @@ define(function (require) {
         },
         defaultValue: null,
         attributes: {},
-        cssClasses: '',
-        uploadInformation: {
-            url: '/upload',
-            accept: '*'
-        }
+        cssClasses: ''
     };
 
     /**

--- a/src/javascripts/ng-admin/Main/component/service/config/Reference.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/Reference.js
@@ -6,7 +6,7 @@ define(function (require) {
     var angular = require('angular'),
         Configurable = require('ng-admin/Main/component/service/config/Configurable'),
         ListView = require('ng-admin/Main/component/service/config/view/ListView'),
-        Field = require('ng-admin/Main/component/service/config/Field'),
+        ChoiceField = require('ng-admin/Main/component/service/config/fieldTypes/ChoiceField'),
         utils = require('ng-admin/lib/utils');
 
     var config = {
@@ -23,7 +23,7 @@ define(function (require) {
      * @constructor
      */
     function Reference(fieldName) {
-        Field.apply(this, arguments);
+        ChoiceField.apply(this, arguments);
         this.config = angular.extend(this.config, angular.copy(config));
         this.config.isDetailLink = true; // because the Field constructor overrides the default
         this.config.validation = { required: false };
@@ -34,7 +34,7 @@ define(function (require) {
         this.referencedView = new ListView();
     }
 
-    utils.inherits(Reference, Field);
+    utils.inherits(Reference, ChoiceField);
     Configurable(Reference.prototype, config);
 
     /**

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ChoiceField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ChoiceField.js
@@ -1,0 +1,30 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function ChoiceField(fieldName) {
+        Field.apply(this, arguments);
+        this._choices = [];
+    }
+
+    utils.inherits(ChoiceField, Field);
+
+    ChoiceField.prototype.choices = function(value) {
+        if (!arguments.length) return this._choices;
+        this._choices = value;
+        return this;
+    };
+
+    ChoiceField.prototype.getLabelForChoice = function(value) {
+        var choice = this._choices.filter(function(choice) { 
+            return choice.value == value 
+        }).pop();
+        return choice ? choice.label : null;
+    };
+
+    return ChoiceField;
+});

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/DateField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/DateField.js
@@ -1,0 +1,32 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function DateField(fieldName) {
+        Field.apply(this, arguments);
+        this._format = 'yyyy-MM-dd';
+        this._parse = function (date) {
+            return date;
+        };
+    }
+
+    utils.inherits(DateField, Field);
+
+    DateField.prototype.format = function(value) {
+        if (!arguments.length) return this._format;
+        this._format = value;
+        return this;
+    };
+
+    DateField.prototype.parse = function(value) {
+        if (!arguments.length) return this._parse;
+        this._parse = value;
+        return this;
+    };
+
+    return DateField;
+});

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/FileField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/FileField.js
@@ -1,0 +1,26 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function FileField(fieldName) {
+        Field.apply(this, arguments);
+        this._uploadInformation = {
+            url: '/upload',
+            accept: '*'
+        };
+    }
+
+    utils.inherits(FileField, Field);
+
+    FileField.prototype.uploadInformation = function(value) {
+        if (!arguments.length) return this._uploadInformation;
+        this._uploadInformation = value;
+        return this;
+    }
+
+    return FileField;
+});

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferenceField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferenceField.js
@@ -22,7 +22,7 @@ define(function (require) {
     /**
      * @constructor
      */
-    function Reference(fieldName) {
+    function ReferenceField(fieldName) {
         ChoiceField.apply(this, arguments);
         this.config = angular.extend(this.config, angular.copy(config));
         this.config.isDetailLink = true; // because the Field constructor overrides the default
@@ -34,15 +34,15 @@ define(function (require) {
         this.referencedView = new ListView();
     }
 
-    utils.inherits(Reference, ChoiceField);
-    Configurable(Reference.prototype, config);
+    utils.inherits(ReferenceField, ChoiceField);
+    Configurable(ReferenceField.prototype, config);
 
     /**
      * Returns all choices by id for a Reference from values : [{targetIdentifier: targetLabel}]
      *
      * @returns {Object}
      */
-    Reference.prototype.getChoicesById = function () {
+    ReferenceField.prototype.getChoicesById = function () {
         var result = {},
             entry,
             targetEntity = this.targetEntity(),
@@ -65,7 +65,7 @@ define(function (require) {
      *
      * @returns {Array}
      */
-    Reference.prototype.choices = function () {
+    ReferenceField.prototype.choices = function () {
         var results = [],
             entry,
             targetEntity = this.targetEntity(),
@@ -93,7 +93,7 @@ define(function (require) {
      *
      * @returns {Entity|Reference}
      */
-    Reference.prototype.targetEntity = function (entity) {
+    ReferenceField.prototype.targetEntity = function (entity) {
         if (arguments.length === 0) {
             return this.config.targetEntity;
         }
@@ -111,7 +111,7 @@ define(function (require) {
      *
      * @returns {Field|Reference}
      */
-    Reference.prototype.targetField = function (field) {
+    ReferenceField.prototype.targetField = function (field) {
         if (arguments.length === 0) {
             return this.config.targetField;
         }
@@ -127,22 +127,22 @@ define(function (require) {
     /**
      * @returns {ListView} a fake view that keep information about the targeted entity
      */
-    Reference.prototype.getReferencedView = function () {
+    ReferenceField.prototype.getReferencedView = function () {
         var referencedView = this.referencedView;
         this.referencedView.perPage(this.perPage());
 
         return referencedView;
     };
 
-    Reference.prototype.hasSingleApiCall = function () {
+    ReferenceField.prototype.hasSingleApiCall = function () {
         return typeof this.config.singleApiCall === 'function';
     };
 
-    Reference.prototype.getSingleApiCall = function (identifiers) {
+    ReferenceField.prototype.getSingleApiCall = function (identifiers) {
         return this.hasSingleApiCall() ? this.config.singleApiCall(identifiers) : this.config.singleApiCall;
     };
 
-    Reference.prototype.getSortFieldName = function () {
+    ReferenceField.prototype.getSortFieldName = function () {
         return this.referencedView.name() + '.' + this.targetField().name();
     };
 
@@ -153,7 +153,7 @@ define(function (require) {
      *
      * @returns {Array}
      */
-    Reference.prototype.getIdentifierValues = function (rawValues) {
+    ReferenceField.prototype.getIdentifierValues = function (rawValues) {
         var results = {},
             identifierName = this.name(),
             identifier,
@@ -178,7 +178,7 @@ define(function (require) {
     /**
      * @returns {[Object]}
      */
-    Reference.prototype.getEntries = function () {
+    ReferenceField.prototype.getEntries = function () {
         return this.entries;
     };
 
@@ -186,7 +186,7 @@ define(function (require) {
      * @param {[Object]} entries
      * @returns {Reference}
      */
-    Reference.prototype.setEntries = function (entries) {
+    ReferenceField.prototype.setEntries = function (entries) {
         this.entries = entries;
 
         return this;
@@ -197,9 +197,9 @@ define(function (require) {
      *
      * @returns mixed
      */
-    Reference.prototype.getListValue = function () {
+    ReferenceField.prototype.getListValue = function () {
         return this.referencedValue;
     };
 
-    return Reference;
+    return ReferenceField;
 });

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField.js
@@ -3,7 +3,7 @@
 define(function (require) {
     'use strict';
 
-    var Reference = require('ng-admin/Main/component/service/config/Reference'),
+    var ReferenceField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'),
         utils = require('ng-admin/lib/utils');
 
     /**
@@ -11,13 +11,13 @@ define(function (require) {
      *
      * @param {String} name
      */
-    function ReferenceMany(name) {
-        Reference.apply(this, arguments);
+    function ReferenceManyField(name) {
+        ReferenceField.apply(this, arguments);
         this.config.name = name || 'reference-many';
         this.config.type = 'reference_many';
     }
 
-    utils.inherits(ReferenceMany, Reference);
+    utils.inherits(ReferenceManyField, ReferenceField);
 
-    return ReferenceMany;
+    return ReferenceManyField;
 });

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferencedListField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferencedListField.js
@@ -21,6 +21,7 @@ define(function (require) {
     function ReferencedListField(fieldName) {
         ReferenceField.apply(this, arguments);
         this.config = angular.extend(this.config, angular.copy(config));
+        this.config.isDetailLink = false;
         this.config.list = false;
         this.config.name = fieldName || 'reference';
         this.config.type = 'referenced_list';

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferencedListField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/ReferencedListField.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     var angular = require('angular'),
         Configurable = require('ng-admin/Main/component/service/config/Configurable'),
-        Reference = require('ng-admin/Main/component/service/config/Reference'),
+        ReferenceField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'),
         utils = require('ng-admin/lib/utils');
 
     var config = {
@@ -18,8 +18,8 @@ define(function (require) {
     /**
      * @constructor
      */
-    function ReferencedList(fieldName) {
-        Reference.apply(this, arguments);
+    function ReferencedListField(fieldName) {
+        ReferenceField.apply(this, arguments);
         this.config = angular.extend(this.config, angular.copy(config));
         this.config.list = false;
         this.config.name = fieldName || 'reference';
@@ -27,8 +27,8 @@ define(function (require) {
         this.entries = [];
     }
 
-    utils.inherits(ReferencedList, Reference);
-    Configurable(ReferencedList.prototype, config);
+    utils.inherits(ReferencedListField, ReferenceField);
+    Configurable(ReferencedListField.prototype, config);
 
     /**
      * Set or get the type
@@ -36,7 +36,7 @@ define(function (require) {
      * @param {[Field]} targetFields
      * @returns ReferencedList
      */
-    ReferencedList.prototype.targetFields = function (targetFields) {
+    ReferencedListField.prototype.targetFields = function (targetFields) {
         if (arguments.length === 0) {
             return this.config.targetFields;
         }
@@ -52,7 +52,7 @@ define(function (require) {
      *
      * @returns {Array}
      */
-    ReferencedList.prototype.getGridColumns = function () {
+    ReferencedListField.prototype.getGridColumns = function () {
         var columns = [],
             field,
             i,
@@ -69,19 +69,19 @@ define(function (require) {
         return columns;
     };
 
-    ReferencedList.prototype.getEntries = function () {
+    ReferencedListField.prototype.getEntries = function () {
         return this.entries;
     };
 
-    ReferencedList.prototype.setEntries = function (entries) {
+    ReferencedListField.prototype.setEntries = function (entries) {
         this.entries = entries;
 
         return this;
     };
 
-    ReferencedList.prototype.clear = function () {
+    ReferencedListField.prototype.clear = function () {
         return this;
     };
 
-    return ReferencedList;
+    return ReferencedListField;
 });

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/TemplateField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/TemplateField.js
@@ -1,0 +1,29 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function TemplateField(fieldName) {
+        Field.apply(this, arguments);
+        this._template = function defaultValueTemplate(entry) {
+            return '';
+        };
+    }
+
+    utils.inherits(TemplateField, Field);
+
+    TemplateField.prototype.template = function(value) {
+        if (!arguments.length) return this._template;
+        this._template = value;
+        return this;
+    }
+
+    TemplateField.prototype.getTemplateValue = function (data) {
+        return typeof (this._template) === 'function' ? this._template(data) : this._template;
+    };
+
+    return TemplateField;
+});

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/WysiwygField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/WysiwygField.js
@@ -1,0 +1,23 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function WysiwygField(fieldName) {
+        Field.apply(this, arguments);
+        this._stripTags = false;
+    }
+
+    utils.inherits(WysiwygField, Field);
+
+    WysiwygField.prototype.stripTags = function(value) {
+        if (!arguments.length) return this._stripTags;
+        this._stripTags = value;
+        return this;
+    }
+
+    return WysiwygField;
+});

--- a/src/javascripts/ng-admin/Main/config/factories.js
+++ b/src/javascripts/ng-admin/Main/config/factories.js
@@ -17,9 +17,9 @@ define(function () {
         nga.registerFieldType('json', Field);
         nga.registerFieldType('number', Field);
         nga.registerFieldType('password', Field);
-        nga.registerFieldType('reference', require('ng-admin/Main/component/service/config/Reference'));
-        nga.registerFieldType('reference_many', require('ng-admin/Main/component/service/config/ReferenceMany'));
-        nga.registerFieldType('referenced_list', require('ng-admin/Main/component/service/config/ReferencedList'));
+        nga.registerFieldType('reference', require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'));
+        nga.registerFieldType('reference_many', require('ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField'));
+        nga.registerFieldType('referenced_list', require('ng-admin/Main/component/service/config/fieldTypes/ReferencedListField'));
         nga.registerFieldType('string', Field);
         nga.registerFieldType('template', require('ng-admin/Main/component/service/config/fieldTypes/TemplateField'));
         nga.registerFieldType('text', Field);

--- a/src/javascripts/ng-admin/Main/config/factories.js
+++ b/src/javascripts/ng-admin/Main/config/factories.js
@@ -4,26 +4,24 @@ define(function () {
     'use strict';
 
     var Field = require('ng-admin/Main/component/service/config/Field'),
-        Reference = require('ng-admin/Main/component/service/config/Reference'),
-        ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany'),
-        ReferencedList = require('ng-admin/Main/component/service/config/ReferencedList');
+        ChoiceField = require('ng-admin/Main/component/service/config/fieldTypes/ChoiceField');
 
     function factories(nga) {
 
         nga.registerFieldType('boolean', Field);
-        nga.registerFieldType('choice', Field);
-        nga.registerFieldType('choices', Field);
+        nga.registerFieldType('choice', ChoiceField);
+        nga.registerFieldType('choices', ChoiceField);
         nga.registerFieldType('date', require('ng-admin/Main/component/service/config/fieldTypes/DateField'));
         nga.registerFieldType('email', Field);
         nga.registerFieldType('file', Field);
         nga.registerFieldType('json', Field);
         nga.registerFieldType('number', Field);
         nga.registerFieldType('password', Field);
-        nga.registerFieldType('reference', Reference);
-        nga.registerFieldType('reference_many', ReferenceMany);
-        nga.registerFieldType('referenced_list', ReferencedList);
+        nga.registerFieldType('reference', require('ng-admin/Main/component/service/config/Reference'));
+        nga.registerFieldType('reference_many', require('ng-admin/Main/component/service/config/ReferenceMany'));
+        nga.registerFieldType('referenced_list', require('ng-admin/Main/component/service/config/ReferencedList'));
         nga.registerFieldType('string', Field);
-        nga.registerFieldType('template', Field);
+        nga.registerFieldType('template', require('ng-admin/Main/component/service/config/fieldTypes/TemplateField'));
         nga.registerFieldType('text', Field);
         nga.registerFieldType('wysiwyg', require('ng-admin/Main/component/service/config/fieldTypes/WysiwygField'));
     }

--- a/src/javascripts/ng-admin/Main/config/factories.js
+++ b/src/javascripts/ng-admin/Main/config/factories.js
@@ -13,7 +13,7 @@ define(function () {
         nga.registerFieldType('boolean', Field);
         nga.registerFieldType('choice', Field);
         nga.registerFieldType('choices', Field);
-        nga.registerFieldType('date', Field);
+        nga.registerFieldType('date', require('ng-admin/Main/component/service/config/fieldTypes/DateField'));
         nga.registerFieldType('email', Field);
         nga.registerFieldType('file', Field);
         nga.registerFieldType('json', Field);
@@ -25,7 +25,7 @@ define(function () {
         nga.registerFieldType('string', Field);
         nga.registerFieldType('template', Field);
         nga.registerFieldType('text', Field);
-        nga.registerFieldType('wysiwyg', Field);
+        nga.registerFieldType('wysiwyg', require('ng-admin/Main/component/service/config/fieldTypes/WysiwygField'));
     }
 
     factories.$inject = ['NgAdminConfigurationProvider'];

--- a/src/javascripts/ng-admin/Main/config/factories.js
+++ b/src/javascripts/ng-admin/Main/config/factories.js
@@ -13,7 +13,7 @@ define(function () {
         nga.registerFieldType('choices', ChoiceField);
         nga.registerFieldType('date', require('ng-admin/Main/component/service/config/fieldTypes/DateField'));
         nga.registerFieldType('email', Field);
-        nga.registerFieldType('file', Field);
+        nga.registerFieldType('file', require('ng-admin/Main/component/service/config/fieldTypes/FileField'));
         nga.registerFieldType('json', Field);
         nga.registerFieldType('number', Field);
         nga.registerFieldType('password', Field);

--- a/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     describe('directive: choice-field', function () {
         var directive = require('ng-admin/Crud/field/maChoiceField');
-        var Field = require('ng-admin/Main/component/service/config/Field');
+        var ChoiceField = require('ng-admin/Main/component/service/config/fieldTypes/ChoiceField');
         angular.module('testapp_ChoiceField', []).directive('maChoiceField', directive);
         require('angular-mocks');
 
@@ -21,21 +21,21 @@ define(function (require) {
         }));
 
         it("should contain a select tag", function () {
-            scope.field = new Field();
+            scope.field = new ChoiceField();
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.children()[0].nodeName).toBe('SELECT');
         });
 
         it("should add any supplied attribute", function () {
-            scope.field = new Field().attributes({ disabled: true });
+            scope.field = new ChoiceField().attributes({ disabled: true });
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.children()[0].disabled).toBeTruthy();
         });
 
         it("should provide an initial option for non-required fields", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'bar'}
             ]);
             var element = $compile(directiveUsage)(scope);
@@ -49,7 +49,7 @@ define(function (require) {
         });
 
         it("should provide an initial option for non-required fields", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'bar'}
             ]).validation({ required: true });
             var element = $compile(directiveUsage)(scope);
@@ -62,7 +62,7 @@ define(function (require) {
         });
 
         it("should contain the choices as options", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'bar'},
                 {label: 'baz', value: 'bazValue'}
             ]);
@@ -77,7 +77,7 @@ define(function (require) {
         });
 
         it("should have the option with the bounded value selected", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'bar'},
                 {label: 'baz', value: 'bazValue'}
             ]);

--- a/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     describe('directive: choices-field', function() {
         var directive = require('ng-admin/Crud/field/maChoicesField');
-        var Field = require('ng-admin/Main/component/service/config/Field');
+        var ChoiceField = require('ng-admin/Main/component/service/config/fieldTypes/ChoiceField');
         angular.module('testapp_ChoicesField', []).directive('maChoicesField', directive);
         require('angular-mocks');
 
@@ -21,7 +21,7 @@ define(function (require) {
         }));
 
         it("should contain a select multiple tag", function () {
-            scope.field = new Field();
+            scope.field = new ChoiceField();
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.children()[0].nodeName).toBe('SELECT');
@@ -29,14 +29,14 @@ define(function (require) {
         });
 
         it("should add any supplied attribute", function () {
-            scope.field = new Field().attributes({ disabled: true });
+            scope.field = new ChoiceField().attributes({ disabled: true });
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.children()[0].disabled).toBeTruthy();
         });
 
         it("should contain the choices as options", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'bar'},
                 {label: 'baz', value: 'bazValue'}
             ]);
@@ -50,7 +50,7 @@ define(function (require) {
         });
 
         it("should have the options with the bounded value selected", function () {
-            scope.field = new Field().choices([
+            scope.field = new ChoiceField().choices([
                 {label: 'foo', value: 'fooValue'},
                 {label: 'bar', value: 'barValue'},
                 {label: 'baz', value: 'bazValue'}

--- a/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     describe('directive: date-field', function() {
         var directive = require('ng-admin/Crud/field/maDateField');
-        var Field = require('ng-admin/Main/component/service/config/Field');
+        var DateField = require('ng-admin/Main/component/service/config/fieldTypes/DateField');
         angular.module('testapp_DateField', []).directive('maDateField', directive);
         require('angular-mocks');
 
@@ -21,21 +21,21 @@ define(function (require) {
         }));
 
         it("should contain an input tag", function () {
-            scope.field = new Field();
+            scope.field = new DateField();
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.find('input').eq(0).attr('type')).toBe('text');
         });
 
         it("should add any supplied attribute", function () {
-            scope.field = new Field().attributes({ placeholder: 'here the date' });
+            scope.field = new DateField().attributes({ placeholder: 'here the date' });
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.find('input').eq(0).attr('placeholder')).toEqual('here the date');
         });
 
         it("should contain the bounded value", function () {
-            scope.field = new Field();
+            scope.field = new DateField();
             var now = new Date();
             scope.value = now;
             var element = $compile(directiveUsage)(scope);

--- a/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
@@ -27,6 +27,15 @@ define(function (require) {
             expect(element.find('input').eq(0).attr('type')).toBe('text');
         });
 
+        it("should use the supplied format as datepicker parameter", function () {
+            scope.field = new DateField().format('yyyy-MM');
+            var date = new Date('2015-01-23');
+            scope.value = date;
+            var element = $compile(directiveUsage)(scope);
+            scope.$digest();
+            expect(element.find('input').eq(0).attr('datepicker-popup')).toBe('yyyy-MM');
+        });
+
         it("should add any supplied attribute", function () {
             scope.field = new DateField().attributes({ placeholder: 'here the date' });
             var element = $compile(directiveUsage)(scope);

--- a/src/javascripts/test/unit/Crud/repository/RetrieveQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/RetrieveQueriesSpec.js
@@ -7,9 +7,9 @@ define(function (require) {
         Field = require('ng-admin/Main/component/service/config/Field'),
         Entity = require('ng-admin/Main/component/service/config/Entity'),
         Entry = require('ng-admin/Main/component/service/config/Entry'),
-        Reference = require('ng-admin/Main/component/service/config/Reference'),
-        ReferencedList = require('ng-admin/Main/component/service/config/ReferencedList'),
-        ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany'),
+        ReferenceField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'),
+        ReferencedListField = require('ng-admin/Main/component/service/config/fieldTypes/ReferencedListField'),
+        ReferenceManyField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField'),
         Restangular = require('mock/Restangular'),
         mixins = require('mixins'),
         $q = require('mock/q'),
@@ -41,7 +41,7 @@ define(function (require) {
             catView = catEntity.listView()
                 .addField(new Field('id').identifier(true))
                 .addField(new Field('name').type('text'))
-                .addField(new Reference('human_id').targetEntity(humanEntity).targetField(new Field('firstName')));
+                .addField(new ReferenceField('human_id').targetEntity(humanEntity).targetField(new Field('firstName')));
 
             humanEntity.identifier(new Field('id'));
 
@@ -94,7 +94,7 @@ define(function (require) {
             var retrieveQueries = new RetrieveQueries($q, Restangular, config),
                 post = new Entity('posts'),
                 author = new Entity('authors'),
-                authorRef = new Reference('author');
+                authorRef = new ReferenceField('author');
 
             var rawPosts = [
                 {id: 1, author: 'abc'},
@@ -127,7 +127,7 @@ define(function (require) {
             var retrieveQueries = new RetrieveQueries($q, Restangular, config),
                 post = new Entity('posts'),
                 author = new Entity('authors'),
-                authorRef = new Reference('author');
+                authorRef = new ReferenceField('author');
 
             authorRef.singleApiCall(function (ids) {
                 return {
@@ -172,7 +172,7 @@ define(function (require) {
                 state = new Entity('states'),
                 stateId = new Field('id').identifier(true),
                 character = new Entity('characters'),
-                stateCharacters = new ReferencedList('character');
+                stateCharacters = new ReferencedListField('character');
 
             var rawCharacters = [
                 {id: 'abc', state_id: 1, name: 'Rollo', age: 35, eyes: 'blue'},
@@ -214,8 +214,8 @@ define(function (require) {
                 entry3 = new Entry(),
                 human = new Entity('humans'),
                 tag = new Entity('tags'),
-                ref1 = new Reference('human_id'),
-                ref2 = new ReferenceMany('tags');
+                ref1 = new ReferenceField('human_id'),
+                ref2 = new ReferenceManyField('tags');
 
             human.editionView().identifier(new Field('id'));
             tag.editionView().identifier(new Field('id'));

--- a/src/javascripts/test/unit/Main/component/service/config/FieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/FieldSpec.js
@@ -39,22 +39,6 @@ define(function (require) {
                 expect(field.name()).not.toBe(null);
             });
 
-            it('should accept string for template value.', function () {
-                var field = new Field('myField')
-                    .type('template')
-                    .template('hello!');
-
-                expect(field.getTemplateValue()).toEqual('hello!');
-            });
-
-            it('should accept function for template value.', function () {
-                var field = new Field('myField')
-                    .type('template')
-                    .template(function () { return 'hello function !'; });
-
-                expect(field.getTemplateValue()).toEqual('hello function !');
-            });
-
             it('should allow even custom types', function () {
                 var field = new Field()
                     .type('myType');

--- a/src/javascripts/test/unit/Main/component/service/config/FieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/FieldSpec.js
@@ -10,7 +10,7 @@ define(function (require) {
 
     describe("Service: Field config", function () {
 
-        describe('label', function() {
+        describe('label()', function() {
             it('should return the camelCased name by default', function () {
                 expect(new Field('myField').label()).toEqual('MyField');
                 expect(new Field('my_field_1').label()).toEqual('My Field 1');
@@ -25,29 +25,52 @@ define(function (require) {
 
         });
 
-        describe('type', function () {
+        describe('type()', function () {
             it('should set type string.', function () {
-                var field = new Field();
-                field.type('string');
-
+                var field = new Field().type('string');
                 expect(field.type()).toBe('string');
             });
 
             it('should have a name even when not set.', function () {
                 var field = new Field();
-
                 expect(field.name()).not.toBe(null);
             });
 
             it('should allow even custom types', function () {
-                var field = new Field()
-                    .type('myType');
+                var field = new Field().type('myType');
                 expect(true).toBeTruthy();
             });
-
         });
 
-        describe('validation', function() {
+        describe('map()', function() {
+            it('should add a map function', function() {
+                var fooFunc = function(a) { return a; }
+                var field = new Field().map(fooFunc);
+                expect(field.hasMaps()).toBeTruthy();
+                expect(field.map()).toEqual([fooFunc]);
+            });
+            it('should allow multiple calls', function() {
+                var fooFunc = function(a) { return a; }
+                var barFunc = function(a) { return a + 1; }
+                var field = new Field().map(fooFunc).map(barFunc);
+                expect(field.map()).toEqual([fooFunc, barFunc]);
+            });
+        });
+
+        describe('getMappedValue()', function() {
+            it('should return the value argument if no maps', function() {
+                var field = new Field();
+                expect(field.getMappedValue('foobar')).toEqual('foobar');
+            });
+            it('should return the passed transformed by maps', function() {
+                var field = new Field()
+                    .map(function add1(a) { return a + 1; })
+                    .map(function times2(a) { return a * 2; });
+                expect(field.getMappedValue(3)).toEqual(8);
+            });
+        });
+
+        describe('validation()', function() {
             it('should have sensible defaults', function() {
                 expect(new Field().validation()).toEqual({required: false, minlength : 0, maxlength : 99999});
             });
@@ -63,27 +86,22 @@ define(function (require) {
             });
         });
 
-        describe('entity', function () {
-            it('should set view.', function () {
-                var field = new Field('field1'),
-                    view = new ListView('list1');
-
-                view.setEntity(new Entity('myEntity1'));
-
-                expect(view.name() + '.' + field.name()).toBe('list1.field1');
+        describe('getCssClasses()', function() {
+            it('should return an empty string by default', function() {
+                var field = new Field();
+                expect(field.getCssClasses()).toEqual('');
             });
-        });
-
-        describe('config', function () {
-            it('should call getMappedValue.', function () {
-                function truncate(val) {
-                    return 'v' + val;
-                }
-
-                var field = new Field('field1');
-                field.map(truncate);
-
-                expect(field.getMappedValue(123)).toBe('v123');
+            it('should return an class string as set by cssClasses(string)', function() {
+                var field = new Field().cssClasses('foo bar');
+                expect(field.getCssClasses()).toEqual('foo bar');
+            });
+            it('should return an class string as set by cssClasses(array)', function() {
+                var field = new Field().cssClasses(['foo', 'bar']);
+                expect(field.getCssClasses()).toEqual('foo bar');
+            });
+            it('should return an class string as set by cssClasses(function)', function() {
+                var field = new Field().cssClasses(function() { return 'foo bar'; });
+                expect(field.getCssClasses()).toEqual('foo bar');
             });
         });
 

--- a/src/javascripts/test/unit/Main/component/service/config/fieldTypes/ReferenceFieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/fieldTypes/ReferenceFieldSpec.js
@@ -3,17 +3,17 @@
 define(function (require) {
     'use strict';
 
-    var Reference = require('ng-admin/Main/component/service/config/Reference'),
+    var ReferenceField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'),
         Field = require('ng-admin/Main/component/service/config/Field'),
         Entry = require('ng-admin/Main/component/service/config/Entry'),
         ListView = require('ng-admin/Main/component/service/config/view/ListView'),
         EditView = require('ng-admin/Main/component/service/config/view/EditView'),
         Entity = require('ng-admin/Main/component/service/config/Entity');
 
-    describe("Service: config/Reference", function () {
+    describe("Service: config/fieldTypes/ReferenceField", function () {
         describe('getChoicesById', function () {
             it('should retrieve choices by id.', function () {
-                var ref = new Reference('human_id'),
+                var ref = new ReferenceField('human_id'),
                     human = new Entity('human');
 
                 human
@@ -41,7 +41,7 @@ define(function (require) {
 
         describe('choices', function () {
             it('should retrieve choices.', function () {
-                var ref = new Reference('human_id'),
+                var ref = new ReferenceField('human_id'),
                     human = new Entity('human');
 
                 human
@@ -73,7 +73,7 @@ define(function (require) {
                 comment = new Entity('comments');
 
             comment.listView()
-                .addField(new Reference('post_id')
+                .addField(new ReferenceField('post_id')
                     .targetEntity(post)
                     .targetField(new Field('id'))
                 );
@@ -83,7 +83,7 @@ define(function (require) {
 
         describe('getSortFieldName', function () {
             it('should retrieve sortField', function () {
-                var ref = new Reference('human_id'),
+                var ref = new ReferenceField('human_id'),
                     human = new Entity('human');
 
                 ref.setEntries([
@@ -107,7 +107,7 @@ define(function (require) {
 
         describe('getIdentifierValues', function () {
             it('Should return identifier values', function () {
-                var view = new Reference('tags'),
+                var view = new ReferenceField('tags'),
                     identifiers;
 
                 identifiers = view.getIdentifierValues([{_id: 1, tags:[1, 3]}, {_id:3, id:6, tags:[4, 3]}]);
@@ -115,7 +115,7 @@ define(function (require) {
             });
 
             it('Should not return undefined values', function () {
-                var view = new Reference('tags'),
+                var view = new ReferenceField('tags'),
                     identifiers;
 
                 identifiers = view.getIdentifierValues([{_id: 1, tags:undefined}, {_id:3, id:6, tags:[3]}]);

--- a/src/javascripts/test/unit/Main/component/service/config/fieldTypes/ReferencedListFieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/fieldTypes/ReferencedListFieldSpec.js
@@ -3,19 +3,19 @@
 define(function (require) {
     'use strict';
 
-    var ReferencedList = require('ng-admin/Main/component/service/config/ReferencedList'),
+    var ReferencedListField = require('ng-admin/Main/component/service/config/fieldTypes/ReferencedListField'),
         Field = require('ng-admin/Main/component/service/config/Field'),
-        ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany'),
+        ReferenceManyField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField'),
         ListView = require('ng-admin/Main/component/service/config/view/ListView'),
         EditView = require('ng-admin/Main/component/service/config/view/EditView'),
         Entity = require('ng-admin/Main/component/service/config/Entity');
 
-    describe("Service: ReferencedList config", function () {
+    describe("Service: config/fieldTypes/ReferencedList", function () {
 
         it('should retrieve referenceMany fields.', function () {
-            var referencedList = new ReferencedList('myField'),
-                ref1 = new ReferenceMany('ref1'),
-                ref2 = new ReferenceMany('ref2');
+            var referencedList = new ReferencedListField('myField'),
+                ref1 = new ReferenceManyField('ref1'),
+                ref2 = new ReferenceManyField('ref2');
 
             referencedList.targetFields([ref1, ref2]);
 
@@ -26,7 +26,7 @@ define(function (require) {
         });
 
         it('should return information about grid column.', function () {
-            var referencedList = new ReferencedList('myField'),
+            var referencedList = new ReferencedListField('myField'),
                 field1 = new Field('f1').label('Field 1'),
                 field2 = new Field('f2').label('Field 2');
 
@@ -44,7 +44,7 @@ define(function (require) {
 
             var post = new Entity('posts');
             post.editionView()
-                .addField(new ReferencedList('comments')
+                .addField(new ReferencedListField('comments')
                     .targetEntity(comment)
                     .targetField(new Field('id'))
                 );

--- a/src/javascripts/test/unit/Main/component/service/config/fieldTypes/TemplateFieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/fieldTypes/TemplateFieldSpec.js
@@ -1,0 +1,30 @@
+/*global define,jasmine,angular,describe,it,expect*/
+
+define(function (require) {
+    'use strict';
+
+    var TemplateField = require('ng-admin/Main/component/service/config/fieldTypes/TemplateField');
+
+    describe("Service: config/fieldTypes/TemplateField", function () {
+
+        describe('template()', function () {
+
+            it('should accept string values', function () {
+                var field = new TemplateField('myField')
+                    .type('template')
+                    .template('hello!');
+
+                expect(field.getTemplateValue()).toEqual('hello!');
+            });
+
+            it('should accept function values', function () {
+                var field = new TemplateField('myField')
+                    .type('template')
+                    .template(function () { return 'hello function !'; });
+
+                expect(field.getTemplateValue()).toEqual('hello function !');
+            });
+
+        });
+    });
+});

--- a/src/javascripts/test/unit/Main/component/service/config/fieldTypes/TemplateFieldSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/fieldTypes/TemplateFieldSpec.js
@@ -10,21 +10,22 @@ define(function (require) {
         describe('template()', function () {
 
             it('should accept string values', function () {
-                var field = new TemplateField('myField')
-                    .type('template')
-                    .template('hello!');
-
+                var field = new TemplateField().template('hello!');
                 expect(field.getTemplateValue()).toEqual('hello!');
             });
 
             it('should accept function values', function () {
-                var field = new TemplateField('myField')
-                    .type('template')
-                    .template(function () { return 'hello function !'; });
-
+                var field = new TemplateField().template(function () { return 'hello function !'; });
                 expect(field.getTemplateValue()).toEqual('hello function !');
             });
 
         });
+
+        describe('getTemplateValue()', function() {
+            it('should return the template function executed with the supplied data', function() {
+                var field = new TemplateField().template(function (name) { return 'hello ' + name + ' !'; });
+                expect(field.getTemplateValue('John')).toEqual('hello John !');
+            });
+        })
     });
 });

--- a/src/javascripts/test/unit/Main/component/service/config/view/ViewSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/view/ViewSpec.js
@@ -6,8 +6,8 @@ define(function (require) {
     var View = require('ng-admin/Main/component/service/config/view/View'),
         Field = require('ng-admin/Main/component/service/config/Field'),
         Entity = require('ng-admin/Main/component/service/config/Entity'),
-        ReferenceMany = require('ng-admin/Main/component/service/config/ReferenceMany'),
-        Reference = require('ng-admin/Main/component/service/config/Reference');
+        ReferenceManyField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField'),
+        ReferenceField = require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField');
 
     describe("Service: View config", function () {
 
@@ -52,8 +52,8 @@ define(function (require) {
         describe('addField()', function() {
             it('should add fields and preserve the order', function () {
                 var view = new View();
-                var refMany = new ReferenceMany('refMany');
-                var ref = new Reference('myRef');
+                var refMany = new ReferenceManyField('refMany');
+                var ref = new ReferenceField('myRef');
 
                 var field = new Field('body');
 


### PR DESCRIPTION
This finishes the Factory refactoring by using specialized configuration field classes under the hood.

`new Field().type('date')`doesn't work anymore after this patch is merged, it breaks compatibility with 0.5.

Follows #325 and refs #294 