### PR TITLE
[RFR] Add <ma-filtered-list-button> directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ A button linking to an entity list view, prefiltered.
 entity.listView().fields([
     // ...
     nga.field('', 'template').label('')
-        template('<ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id" size="sm">')
+        template('<ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm">')
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,18 @@ entity.listView().fields([
 
 A button linking to the related view for the given entity.
 
+* `<ma-filtered-list-button>`
+
+A button linking to an entity list view, prefiltered.
+
+```js
+entity.listView().fields([
+    // ...
+    nga.field('', 'template').label('')
+        template('<ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id" size="sm">')
+]);
+```
+
 ### `listView.listActions()`
 
 The `listActions()` method available on the listView is a shortcut to adding a template field with one of the directives listed above. In practice, calling:

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -113,7 +113,9 @@
                     .targetFields([
                         nga.field('id'),
                         nga.field('body').label('Comment')
-                    ])
+                    ]),
+                nga.field('', 'template').label('')
+                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id" text="" size="sm"></ma-filtered-list-button></span>')
             ]);
 
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -115,7 +115,7 @@
                         nga.field('body').label('Comment')
                     ]),
                 nga.field('', 'template').label('')
-                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id" text="" size="sm"></ma-filtered-list-button></span>')
+                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm"></ma-filtered-list-button></span>')
             ]);
 
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -64,6 +64,7 @@ define(function (require) {
     CrudModule.directive('maBackButton', require('ng-admin/Crud/button/maBackButton'));
     CrudModule.directive('maCreateButton', require('ng-admin/Crud/button/maCreateButton'));
     CrudModule.directive('maEditButton', require('ng-admin/Crud/button/maEditButton'));
+    CrudModule.directive('maFilteredListButton', require('ng-admin/Crud/button/maFilteredListButton'));
     CrudModule.directive('maShowButton', require('ng-admin/Crud/button/maShowButton'));
     CrudModule.directive('maListButton', require('ng-admin/Crud/button/maListButton'));
     CrudModule.directive('maDeleteButton', require('ng-admin/Crud/button/maDeleteButton'));

--- a/src/javascripts/ng-admin/Crud/button/maFilteredListButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maFilteredListButton.js
@@ -11,8 +11,7 @@ define(function () {
      *     <!-- In a scope where the current entry is a post, link tio the related comments -->
      *     <ma-filtered-list-button 
      *       entity-name="comments"
-     *       filter-name="post_id"
-     *       filter-value="entry.values.id"
+     *       filter="{ post_id: entry.values.id }"
      *       text="See related comments"
      *       size="xs">
      *     </ma-filtered-list-button>')
@@ -21,24 +20,21 @@ define(function () {
      *
      * nga.field('', 'template')
      *   .label('')
-     *   .template('<ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id"></ma-filtered-list-button>')
+     *   .template('<ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }"></ma-filtered-list-button>')
      */
     function maFilteredListButtonDirective($state) {
         return {
             restrict: 'E',
             scope: {
                 entityName: '@',
-                filterName: '@',
-                filterValue: '&',
+                filter: '&',
                 text: '@',
                 size: '@'
             },
             link: function (scope) {
                 scope.buttonText = scope.text || ('See all related ' + scope.entityName);
                 scope.gotoList = function () {
-                    var searchfilter = {};
-                    searchfilter[scope.filterName] = scope.filterValue();
-                    $state.go($state.get('list'), { 'entity': scope.entityName, 'search': searchfilter});
+                    $state.go($state.get('list'), { 'entity': scope.entityName, 'search': scope.filter()});
 
                 };
             },

--- a/src/javascripts/ng-admin/Crud/button/maFilteredListButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maFilteredListButton.js
@@ -1,0 +1,55 @@
+/*global define*/
+
+define(function () {
+    'use strict';
+
+    /**
+     * Link to filtered list
+     * 
+     * Usage:
+     *
+     *     <!-- In a scope where the current entry is a post, link tio the related comments -->
+     *     <ma-filtered-list-button 
+     *       entity-name="comments"
+     *       filter-name="post_id"
+     *       filter-value="entry.values.id"
+     *       text="See related comments"
+     *       size="xs">
+     *     </ma-filtered-list-button>')
+     *
+     * Usage as a template field:
+     *
+     * nga.field('', 'template')
+     *   .label('')
+     *   .template('<ma-filtered-list-button entity-name="comments" filter-name="post_id" filter-value="entry.values.id"></ma-filtered-list-button>')
+     */
+    function maFilteredListButtonDirective($state) {
+        return {
+            restrict: 'E',
+            scope: {
+                entityName: '@',
+                filterName: '@',
+                filterValue: '&',
+                text: '@',
+                size: '@'
+            },
+            link: function (scope) {
+                scope.buttonText = scope.text || ('See all related ' + scope.entityName);
+                scope.gotoList = function () {
+                    var searchfilter = {};
+                    searchfilter[scope.filterName] = scope.filterValue();
+                    $state.go($state.get('list'), { 'entity': scope.entityName, 'search': searchfilter});
+
+                };
+            },
+            template:
+'<a class="btn btn-default" ng-class="size ? \'btn-\' + size : \'\'" ng-click="gotoList()">' +
+    '<span class="glyphicon glyphicon-list" aria-hidden="true"></span>&nbsp;{{ buttonText }}' +
+'</a>'
+        };
+    }
+
+    maFilteredListButtonDirective.$inject = ['$state'];
+
+    return maFilteredListButtonDirective;
+});

--- a/src/javascripts/ng-admin/Crud/button/maListButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maListButton.js
@@ -3,6 +3,12 @@
 define(function () {
     'use strict';
 
+    /**
+     * Link to list
+     * 
+     * Usage:
+     * <ma-list-button entity="entity" size="xs"></ma-list-button>
+     */
     function maListButtonDirective($location) {
         return {
             restrict: 'E',

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -19,11 +19,12 @@ define(function () {
         this.actions = view.actions();
         this.fields = this.$filter('orderElement')(view.fields());
         this.config = Configuration();
+        this.view = view;
+        this.entity = this.view.getEntity();
         this.$scope.edit = this.edit.bind(this);
         this.$scope.entry = entry;
         this.$scope.view = view;
-        this.view = view;
-        this.entity = this.view.getEntity();
+        this.$scope.entity = this.entity;
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };


### PR DESCRIPTION
A reusable directive to automatically link to a prefiltered list.

Usage: 

```js
post.editionView()
    .fields([
        nga.field('comments', 'referenced_list')
            .targetEntity(comment)
            .targetReferenceField('post_id')
            .targetFields([
                nga.field('id'),
                nga.field('body').label('Comment')
            ]),
        nga.field('', 'template').label('')
            .template('<ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm">')
```

![image](https://cloud.githubusercontent.com/assets/99944/6459699/4f3c1a80-c191-11e4-9658-2335da9c0aa5.png)

Refs #338 