### PR TITLE
fix: 404 error for fontawesome-webfont on local example server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,6 +78,12 @@ module.exports = function (grunt) {
                 dest: 'examples/blog/build/',
                 expand: true
             },
+            assets_dev: {
+                cwd: 'assets/',
+                src: ['**'],
+                dest: 'examples/blog/assets/',
+                expand: true
+            },
             js_dev: {
                 src: 'build/ng-admin.min.js',
                 dest: 'examples/blog/build/ng-admin.js'
@@ -147,7 +153,7 @@ module.exports = function (grunt) {
             },
             sass: {
                 files: ['src/sass/*.scss'],
-                tasks: ['compass:dev', 'concat:css', 'copy:fonts_dev', 'copy:css_dev'],
+                tasks: ['compass:dev', 'concat:css', 'copy:fonts_dev', 'copy:assets_dev', 'copy:css_dev'],
                 options: {
                     atBegin: true,
                     livereload: true


### PR DESCRIPTION
Icons from FontAwesome webfont is unavailable when running "make run" in newly clonned repo (with "make install" executed, of course). The reason of such behaviour is the absence of *assets/fonts/* folder in the example root folder */example/blog/*.
So I added "copy:assets_dev" grunt task, which copies assets folder to the example root, and included this task to the "watch:sass" task settings, where it should be IMO.