### PR TITLE
Fix: .editable(false) on "reference" type field in EditView

### DIFF
--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -2,7 +2,7 @@ define(function(require) {
     "use strict";
 
     function getReadWidget() {
-        return '<ma-string-column value="::entry.listValues[field.name()] || entry.values[field.name()]"></ma-string-column>';
+        return '<ma-string-column value="::entry.listValues[field.name()]"></ma-string-column>';
     }
     function getLinkWidget() {
         return '<a ng-click="gotoReference()">' + getReadWidget() + '</a>';

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -2,7 +2,7 @@ define(function(require) {
     "use strict";
 
     function getReadWidget() {
-        return '<ma-string-column value="::entry.listValues[field.name()]"></ma-string-column>';
+        return '<ma-string-column value="::entry.listValues[field.name()] || entry.values[field.name()]"></ma-string-column>';
     }
     function getLinkWidget() {
         return '<a ng-click="gotoReference()">' + getReadWidget() + '</a>';

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -138,7 +138,7 @@ define(function (require) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
                     referencedValues: ['RetrieveQueries', 'view', 'rawEntry', function (RetrieveQueries, view, rawEntry) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences(), [rawEntry.values]);
+                        return RetrieveQueries.getReferencedValues(view.getReferences(), null);
                     }],
                     referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
                         var sortField = $stateParams.sortField,

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -134,17 +134,20 @@ define(function (require) {
                 },
                 resolve: {
                     view: viewProvider('EditView'),
-                    entry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
+                    rawEntry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', 'entry', function (RetrieveQueries, view, entry) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences(), null);
+                    referencedValues: ['RetrieveQueries', 'view', 'rawEntry', function (RetrieveQueries, view, rawEntry) {
+                        return RetrieveQueries.getReferencedValues(view.getReferences(), [rawEntry.values]);
                     }],
-                    referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'entry', function ($stateParams, RetrieveQueries, view, entry) {
+                    referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
                         var sortField = $stateParams.sortField,
                             sortDir = $stateParams.sortDir;
 
-                        return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, entry.identifierValue);
+                        return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, rawEntry.identifierValue);
+                    }],
+                    entry: ['RetrieveQueries', 'rawEntry', 'referencedValues', function(RetrieveQueries, rawEntry, referencedValues) {
+                        return RetrieveQueries.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
                     }]
                 }
             });


### PR DESCRIPTION
When applying *.editable(false)* field method on field of "reference" type for EditView - we get no visible representation of this field - we get a link with empty inner text. This is because of getReadWidget() which passes an empty value to corresponding directive.
So I've slightly changed this function to fix this issue.