### PR TITLE
[RFR] Fix date sent to json_server in blog example

### DIFF
--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -162,7 +162,15 @@
                 nga.field('created_at', 'date')
                     .label('Posted')
                     .attributes({'placeholder': 'Filter by date'})
-                    .format('yyyy-MM-dd'),
+                    .format('yyyy-MM-dd')
+                    .parse(function(date) {
+                        // the backend is dumb and doesn't interpret date objects
+                        // so we convert the date to a string without timezone
+                        var dateObject = date instanceof Date ? date : new Date(date);
+                        dateObject.setMinutes(dateObject.getMinutes() - dateObject.getTimezoneOffset());
+                        var dateString = dateObject.toJSON();
+                        return dateString ? dateString.substr(0,10) : null;
+                    }),
                 nga.field('today', 'boolean').map(function() {
                     var now = new Date(),
                         year = now.getFullYear(),


### PR DESCRIPTION
We used to send a simple string to the backend, now we send a serialized date. Unfortunately, the backend used in the blog example doesn't understand dates, and even less timezones. So we do the job in the frontend of undoing timezone offset and sending the raw date.

Closes #345 