### PR TITLE
[RFR] Number field can now set fractionSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ A list of CSS classes to be added to the corresponding field. If you provide a f
 * `defaultValue(*)`
 Define the default value of the field in the creation form.
 
+### `number` Field Settings
+
+* `fractionSize(integer)`
+Number of decimal places to round the number to. If this is not provided, then the fraction size is computed from the current locale's number formatting pattern.
+
 ### `choice` and `choices` Field Settings
 
 * `choices([{value: '', label: ''}, ...])`

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -55,9 +55,11 @@ define(function (require) {
     CrudModule.directive('maBooleanColumn', require('ng-admin/Crud/column/maBooleanColumn'));
     CrudModule.directive('maChoicesColumn', require('ng-admin/Crud/column/maChoicesColumn'));
     CrudModule.directive('maDateColumn', require('ng-admin/Crud/column/maDateColumn'));
+    CrudModule.directive('maJsonColumn', require('ng-admin/Crud/column/maJsonColumn'));
+    CrudModule.directive('maNumberColumn', require('ng-admin/Crud/column/maNumberColumn'));
+    CrudModule.directive('maReferenceManyColumn', require('ng-admin/Crud/column/maReferenceManyColumn'));
     CrudModule.directive('maReferenceManyLinkColumn', require('ng-admin/Crud/column/maReferenceManyLinkColumn'));
     CrudModule.directive('maStringColumn', require('ng-admin/Crud/column/maStringColumn'));
-    CrudModule.directive('maJsonColumn', require('ng-admin/Crud/column/maJsonColumn'));
     CrudModule.directive('maTemplateColumn', require('ng-admin/Crud/column/maTemplateColumn'));
     CrudModule.directive('maWysiwygColumn', require('ng-admin/Crud/column/maWysiwygColumn'));
 

--- a/src/javascripts/ng-admin/Crud/column/maNumberColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maNumberColumn.js
@@ -1,0 +1,20 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    function maNumberColumn() {
+        return {
+            restrict: 'E',
+            scope: {
+                value: '&',
+                field: '&'
+            },
+            template: '<span>{{ value() | number:field().format() }}</span>'
+        };
+    }
+
+    maNumberColumn.$inject = [];
+
+    return maNumberColumn;
+});

--- a/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
@@ -2,7 +2,7 @@ define(function(require) {
     "use strict";
 
     function getReadWidget() {
-        return '<ma-string-column value="::entry.values[field.name()]"></ma-string-column>';
+        return '<ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column>';
     }
     function getLinkWidget() {
         return '<a ng-click="gotoDetail()">' + getReadWidget() + '</a>';

--- a/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/NumberField.js
+++ b/src/javascripts/ng-admin/Main/component/service/config/fieldTypes/NumberField.js
@@ -1,0 +1,32 @@
+/*global define*/
+
+define(function (require) {
+    'use strict';
+
+    var Field = require('ng-admin/Main/component/service/config/Field'),
+        utils = require('ng-admin/lib/utils');
+
+    function NumberField() {
+        Field.apply(this, arguments);
+        this._fractionSize = undefined;
+    }
+
+    utils.inherits(NumberField, Field);
+
+    /**
+     * Number of decimal places to round the number to. If this is not provided,
+     * then the fraction size is computed from the current locale's number formatting pattern.
+     * In the case of the default locale, it will be 3.
+     *
+     * {@example}
+     *
+     *     nga.field('height', 'number').fractionSize(2);
+     */
+    NumberField.prototype.fractionSize = function(value) {
+        if (!arguments.length) return this._fractionSize;
+        this._fractionSize = value;
+        return this;
+    };
+
+    return NumberField;
+});

--- a/src/javascripts/ng-admin/Main/config/factories.js
+++ b/src/javascripts/ng-admin/Main/config/factories.js
@@ -16,7 +16,7 @@ define(function (require) {
         nga.registerFieldType('email', Field);
         nga.registerFieldType('file', require('ng-admin/Main/component/service/config/fieldTypes/FileField'));
         nga.registerFieldType('json', Field);
-        nga.registerFieldType('number', Field);
+        nga.registerFieldType('number', require('ng-admin/Main/component/service/config/fieldTypes/NumberField'));
         nga.registerFieldType('password', Field);
         nga.registerFieldType('reference', require('ng-admin/Main/component/service/config/fieldTypes/ReferenceField'));
         nga.registerFieldType('reference_many', require('ng-admin/Main/component/service/config/fieldTypes/ReferenceManyField'));


### PR DESCRIPTION
Specializing the 'number' type to allow to set the fractionSize:

```js
nga.field('height', 'number').fractionSize(2);
```

The value 123.45 will render as:

* 123.45 by default
* 123 when `fractionSize` is 0
* 123.4 when `fractionSize` is 1
* 123.45 when `fractionSize` is 2
* 123.456 when `fractionSize` is 3
* etc.