### PR TITLE
[RFR] add an option on maFileField to recover the serverside filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,18 @@ Define the template to be displayed for fields of type `template` (can be a stri
 Give upload information for `file` field type
  - `url`: url for server side upload
  - `accept`: values allowed by the standard HTML file input accept attribute
+ - `apifilename`: filename assigned by the server and returned by your API. 
+ 
+If the uploaded file is renamed server-side, you can get the new filename from an api return.    
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    { "picture_name": "post_12_picture1.jpg"}
+
+you can configure file field as :
+
+    nga.field('picture', 'file').uploadInformation({ 'url': 'your_url', 'apifilename': 'picture_name' })
+
 Some other properties are allowed, see https://github.com/danialfarid/angular-file-upload#upload-service for the complete list.
 
 ## Reusable Directives

--- a/src/javascripts/ng-admin/Crud/field/maFileField.js
+++ b/src/javascripts/ng-admin/Crud/field/maFileField.js
@@ -24,6 +24,7 @@ define(function (require) {
 
                     scope.multiple = uploadInformation.hasOwnProperty('multiple') ? uploadInformation.multiple : false;
                     scope.accept = uploadInformation.hasOwnProperty('accept') ? uploadInformation.accept : '*';
+                    scope.apifilename = uploadInformation.hasOwnProperty('apifilename') ? uploadInformation.apifilename : false;
 
                     var files = scope.value ? scope.value.split(',') : [];
                     scope.files = {};
@@ -58,7 +59,6 @@ define(function (require) {
                         for (var file in selectedFiles) {
                             uploadParams = angular.copy(scope.field().uploadInformation());
                             uploadParams.file = selectedFiles[file];
-
                             $upload
                                 .upload(uploadParams)
                                 .progress(function(evt) {
@@ -69,10 +69,17 @@ define(function (require) {
                                 })
                                 .success(function(data, status, headers, config) {
                                     scope.files[config.file.name] = {
-                                        "name": config.file.name,
+                                        "name": scope.apifilename ? data[scope.apifilename] : config.file.name,
                                         "progress": 0
                                     };
-                                    scope.value = Object.keys(scope.files).join(',');
+                                    if (scope.apifilename) {
+                                        var apiNames = Object.keys(scope.files).map(function(fileindex) {
+                                            return scope.files[fileindex].name;
+                                        });
+                                        scope.value = apiNames.join(',');
+                                    } else {
+                                        scope.value = Object.keys(scope.files).join(',');
+                                    }
                                 })
                                 .error(function(data, status, headers, config) {
                                     delete scope.files[config.file.name];


### PR DESCRIPTION
If the uploaded file is renamed server-side, we can recover the new filename from an api return.