### PR TITLE
support for parameterizing choice fields by the current entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ app.config(function (NgAdminConfigurationProvider) {
         ])
         .listActions(['show', 'edit', 'delete']);
 
+   var categories = [{
+        label : 'Tech',
+        value : 'tech'
+    },{
+        label : 'Lifestyle',
+        value : 'lifestyle'
+    }];
+    var subCategories = [{
+        label : 'Computers',
+        value : 'computers',
+        category : 'tech'
+    }, {
+        label : 'Gadgets',
+        value : 'gadgets',
+        category : 'tech'
+    },{
+        label : 'Travel',
+        value : 'travel',
+        category : 'lifestyle'
+    }, {
+        label : 'Fitness',
+        value : 'fitness',
+        category : 'lifestyle'
+    }];
+
     post.creationView()
         .fields([
             nga.field('title') // the default edit field type is "string", and displays as a text input
@@ -126,6 +151,15 @@ app.config(function (NgAdminConfigurationProvider) {
             nga.field('teaser', 'text'), // text field type translates to a textarea
             nga.field('body', 'wysiwyg'), // overriding the type allows rich text editing for the body
             nga.field('published_at', 'date') // Date field type translates to a datepicker
+            nga.field('category', 'choice')
+                .choices(categories),
+            nga.field('subCategory', 'choice') // choice (and choices) field can be set with a function that returns the set of choices (options) to render. 
+                .label('Sub Category')
+                .choices(function(entry){
+                    return subCategories.filter(function (c) {
+                        return c.category === entry.values.category
+                    });
+                }),
         ]);
 
     post.editionView()

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -94,11 +94,44 @@
                 nga.field('published_at', 'date') // Date field type translates to a datepicker
             ]);
 
+        var categories = [{
+            label : 'Tech',
+            value : 'tech'
+        },{
+            label : 'Lifestyle',
+            value : 'lifestyle'
+        }];
+        var subCategories = [{
+            label : 'Computers',
+            value : 'computers',
+            category : 'tech'
+        }, {
+            label : 'Gadgets',
+            value : 'gadgets',
+            category : 'tech'
+        },{
+            label : 'Travel',
+            value : 'travel',
+            category : 'lifestyle'
+        }, {
+            label : 'Fitness',
+            value : 'fitness',
+            category : 'lifestyle'
+        }];
+
         post.editionView()
             .title('Edit post "{{ entry.values.title }}"') // title() accepts a template string, which has access to the entry
             .actions(['list', 'show', 'delete']) // choose which buttons appear in the top action bar. Show is disabled by default
             .fields([
                 post.creationView().fields(), // fields() without arguments returns the list of fields. That way you can reuse fields from another view to avoid repetition
+                nga.field('category', 'choice')
+                    .choices(categories),
+                nga.field('subCategory', 'choice')
+                    .choices(function(entry){
+                        return subCategories.filter(function (c) {
+                            return c.category === entry.values.category
+                        });
+                    }),
                 nga.field('tags', 'reference_many') // ReferenceMany translates to a select multiple
                     .targetEntity(tag)
                     .targetField(nga.field('name'))

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -12,14 +12,18 @@ define(function (require) {
         return {
             scope: {
                 'field': '&',
-                'value': '='
+                'value': '=',
+                'entry':  '='
             },
             restrict: 'E',
             link: function(scope, element) {
                 var field = scope.field();
                 scope.name = field.name();
-                scope.choices = field.choices();
                 scope.v = field.validation();
+                scope.getChoices = function(entry) {
+                  return field.getChoices(entry);
+                }
+
                 var select = element.children()[0];
                 var attributes = field.attributes();
                 for (var name in attributes) {
@@ -29,7 +33,7 @@ define(function (require) {
             template: 
 '<select ng-model="value" ng-required="v.required" id="{{ name }}" name="{{ name }}" class="form-control">' +
   '<option ng-if="!v.required" value="" ng-selected="!value">-- select a value --</option>' +
-  '<option ng-repeat="choice in choices" value="{{ choice.value }}" ng-selected="value == choice.value">' +
+  '<option ng-repeat="choice in getChoices(entry)" value="{{ choice.value }}" ng-selected="value == choice.value">' +
     '{{ choice.label }}' +
   '</option>' +
 '</select>'

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -6,7 +6,7 @@ define(function (require) {
     /**
      * Edition field for an element in a list - a select.
      *
-     * @example <ma-choice-field field="field" value="value"></ma-choice-field>
+     * @example <ma-choice-field entry="entry" field="field" value="value"></ma-choice-field>
      */
     function maChoiceField() {
         return {
@@ -21,7 +21,7 @@ define(function (require) {
                 scope.name = field.name();
                 scope.v = field.validation();
                 scope.getChoices = function(entry) {
-                  return field.getChoices(entry);
+                    return field.getChoices(entry);
                 }
 
                 var select = element.children()[0];

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -6,20 +6,24 @@ define(function (require) {
     /**
      * Edition field for a selection of elements in a list - a multiple select.
      *
-     * @example <ma-choices-field field="field" value="value"></ma-choices-field>
+     * @example <ma-choices-field entry="entry" field="field" value="value"></ma-choices-field>
      */
     function maChoicesField() {
         return {
             scope: {
                 'field': '&',
-                'value': '='
+                'value': '=',
+                'entry':  '='
             },
             restrict: 'E',
             link: function(scope, element) {
                 var field = scope.field();
                 scope.name = field.name();
-                scope.choices = field.choices();
                 scope.v = field.validation();
+                scope.getChoices = function(entry) {
+                    return field.getChoices(entry);
+                }
+
                 var select = element.children()[0];
                 var attributes = field.attributes();
                 for (var name in attributes) {
@@ -29,7 +33,7 @@ define(function (require) {
             },
             template: 
 '<select multiple ng-model="value" id="{{ name }}" name="{{ name }}" class="form-control" ng-required="v.required">' +
-  '<option ng-repeat="choice in choices" value="{{ choice.value }}" ng-selected="contains(value, choice.value)">' +
+  '<option ng-repeat="choice in getChoices(entry)" value="{{ choice.value }}" ng-selected="contains(value, choice.value)">' +
     '{{ choice.label }}' +
   '</option>' +
 '</select>'

--- a/src/javascripts/ng-admin/Crud/fieldView/ChoiceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ChoiceFieldView.js
@@ -11,7 +11,7 @@ define(function(require) {
         return '<ma-choice-field field="::field" value="values[field.name()]"></ma-choice-field>';
     }
     function getWriteWidget() {
-        return '<ma-choice-field field="::field" value="entry.values[field.name()]"></ma-choice-field>';
+        return '<ma-choice-field field="::field" entry="::entry" value="entry.values[field.name()]"></ma-choice-field>';
     }
     return {
         getReadWidget:   getReadWidget,

--- a/src/javascripts/ng-admin/Crud/fieldView/ChoicesFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ChoicesFieldView.js
@@ -11,7 +11,7 @@ define(function(require) {
         return '<ma-choices-field field="::field" value="values[field.name()]"></ma-choices-field>';
     }
     function getWriteWidget() {
-        return '<ma-choices-field field="::field" value="entry.values[field.name()]"></ma-choices-field>';
+        return '<ma-choices-field field="::field" entry="::entry" value="entry.values[field.name()]"></ma-choices-field>';
     }
     return {
         getReadWidget:   getReadWidget,

--- a/src/javascripts/ng-admin/es6/lib/Field/ChoiceField.js
+++ b/src/javascripts/ng-admin/es6/lib/Field/ChoiceField.js
@@ -5,12 +5,26 @@ class ChoiceField extends Field {
         super(name);
         this._type = "choice";
         this._choices = [];
+        this._choicesFunc = null;
     }
 
     choices(choices) {
         if (!arguments.length) return this._choices;
-        this._choices = choices;
+        if (typeof(choices) == 'function') {
+            this._choicesFunc = choices;
+        } else {
+            this._choices = choices;
+        }
+ 
         return this;
+    }
+
+    getChoices(entry) {
+        if (this._choicesFunc != null){
+            return this._choicesFunc(entry);
+        }
+
+        return this._choices;
     }
 
     getLabelForChoice(value) {

--- a/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
@@ -11,7 +11,7 @@ define(function (require) {
 
         var $compile,
             scope,
-            directiveUsage = '<ma-choice-field field="field" value="value"></ma-choice-field>';
+            directiveUsage = '<ma-choice-field entry="entry" field="field" value="value"></ma-choice-field>';
 
         beforeEach(module('testapp_ChoiceField'));
 
@@ -74,6 +74,38 @@ define(function (require) {
             expect(options[1].value).toEqual('bar');
             expect(options[2].innerHTML).toEqual('baz');
             expect(options[2].value).toEqual('bazValue');
+        });
+
+        it("should contain the choices from choicesFunc as options", function () {
+            var choices = [
+                {label: 'foo', value: 'bar'},
+                {label: 'baz', value: 'bazValue'}
+            ];
+            scope.field = new ChoiceField().choices(function(entry){
+                return choices;
+            });
+            scope.value = 'bar';
+            var element = $compile(directiveUsage)(scope);
+            scope.$digest();
+            var options = element.find('option');
+            expect(options[1].innerHTML).toEqual('foo');
+            expect(options[1].value).toEqual('bar');
+            expect(options[2].innerHTML).toEqual('baz');
+            expect(options[2].value).toEqual('bazValue');
+        });
+
+        it("should pass entry to choicesFunc", function () {
+            var choices = [];
+            var choicesFuncWasCalled = false;
+            scope.entry = {moo: 'boo'};
+            scope.field = new ChoiceField().choices(function(entry){
+                expect(entry.moo).toEqual('boo');
+                choicesFuncWasCalled = true;
+                return choices;
+            });
+            var element = $compile(directiveUsage)(scope);
+            scope.$digest();
+            expect(choicesFuncWasCalled).toBeTruthy();
         });
 
         it("should have the option with the bounded value selected", function () {

--- a/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
@@ -11,7 +11,7 @@ define(function (require) {
 
         var $compile,
             scope,
-            directiveUsage = '<ma-choices-field field="field" value="value"></ma-choices-field>';
+            directiveUsage = '<ma-choices-field entry="entry" field="field" value="value"></ma-choices-field>';
 
         beforeEach(module('testapp_ChoicesField'));
 
@@ -33,6 +33,37 @@ define(function (require) {
             var element = $compile(directiveUsage)(scope);
             scope.$digest();
             expect(element.children()[0].disabled).toBeTruthy();
+        });
+
+        it("should pass entry to choices func", function () {
+            var choices = [];
+            var choicesFuncWasCalled = false;
+            scope.entry = {moo: 'boo'};
+            scope.field = new ChoiceField().choices(function(entry) {
+                expect(entry.moo).toEqual('boo');
+                choicesFuncWasCalled = true;
+                return choices;
+            });
+            var element = $compile(directiveUsage)(scope);
+            scope.$digest();
+            expect(choicesFuncWasCalled).toBeTruthy();
+        });
+
+        it("should contain the choices from choicesFunc as options", function () {
+            var choices = [
+                {label: 'foo', value: 'bar'},
+                {label: 'baz', value: 'bazValue'}
+            ];
+            scope.field = new ChoiceField().choices(function(entry) {
+                return choices;
+            });
+            var element = $compile(directiveUsage)(scope);
+            scope.$digest();
+            var options = element.find('option');
+            expect(options[0].innerHTML).toEqual('foo');
+            expect(options[0].value).toEqual('bar');
+            expect(options[1].innerHTML).toEqual('baz');
+            expect(options[1].value).toEqual('bazValue');
         });
 
         it("should contain the choices as options", function () {


### PR DESCRIPTION
This opens up contextual select tags, e.g. cascading selects.

e.g to create a cascading set of 'state' and 'city' fields, you can now do that:

     nga.field('state', 'choice').choices(states),
     nga.field('city', 'choice').choices(function(entry) {
         return cities.filter(function(city) { return city.state === entry.values.state;} );
     })

given

     var states = [ { value:'WA', label:'Washington'}, ... ];
     var cities = [ { value:'Bellevue', label: 'Bellevue', state: 'WA'} , ... ];

