### PR TITLE
[RFR] Add default admin title

### DIFF
--- a/src/javascripts/ng-admin/es6/lib/Application.js
+++ b/src/javascripts/ng-admin/es6/lib/Application.js
@@ -1,7 +1,7 @@
 import Menu from './Menu/Menu';
 
 class Application {
-    constructor(title) {
+    constructor(title='ng-admin') {
         this._baseApiUrl = null;
         this._customTemplate = function(viewName) {};
         this._title = title;


### PR DESCRIPTION
The admin lost its default title when we moved the config to ES6. Bringing it back.

![image](https://cloud.githubusercontent.com/assets/99944/7049193/fcad4570-de17-11e4-9e1a-e0e316cf8ecc.png)
