### PR TITLE
[RFR] Fix rendering on datagrid by using entry.identifierValue as $$hashKey

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/Datagrid.html
+++ b/src/javascripts/ng-admin/Crud/list/Datagrid.html
@@ -18,7 +18,7 @@
     </thead>
 
     <tbody>
-        <tr ng-repeat="entry in entries track by $index">
+        <tr ng-repeat="entry in entries track by entry.identifierValue">
             <td ng-if="selection">
                 <ma-datagrid-item-selector toggle-select="toggleSelect(entry)" selection="selection" entry="entry"/>
             </td>


### PR DESCRIPTION
When displaying an array in a datagrid, ng-admin uses the array indexes as `$$hashKey`.
Because of that, if you do a `splice` on your array to remove an entry, it could lead to rendering issues.

- [x] Using `entry.identifierValue` into the `track by` for datagrid.