### PR TITLE
[RFR] Introduce DataStore and remove entries for ReferenceField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ src/javascripts/bower_components
 src/javascripts/config.js
 src/styles/*.css
 build/require
+build/es6
+build/ng-admin-configuration.js
+build/ng-admin.css
 src/css
 examples/blog/build
 examples/blog/assets

--- a/src/javascripts/ng-admin.js
+++ b/src/javascripts/ng-admin.js
@@ -57,15 +57,11 @@ define(function (require) {
     require('CrudModule');
 
     var AdminDescription = require('AdminDescription');
-    var adminDescriptionInstance = new AdminDescription();
 
     var factory = angular.module('AdminDescriptionModule', []);
-    factory.constant('AdminDescription', adminDescriptionInstance);
+    factory.constant('AdminDescription', new AdminDescription());
 
-    var dataStore = angular.module('DataStoreModule', []);
-    dataStore.constant('DataStore', adminDescriptionInstance.getDataStore());
-
-    var ngadmin = angular.module('ng-admin', ['main', 'crud', 'AdminDescriptionModule', 'DataStoreModule']);
+    var ngadmin = angular.module('ng-admin', ['main', 'crud', 'AdminDescriptionModule']);
     ngadmin.config(function(NgAdminConfigurationProvider, AdminDescription) {
         NgAdminConfigurationProvider.setAdminDescription(AdminDescription);
     });

--- a/src/javascripts/ng-admin.js
+++ b/src/javascripts/ng-admin.js
@@ -57,11 +57,15 @@ define(function (require) {
     require('CrudModule');
 
     var AdminDescription = require('AdminDescription');
+    var adminDescriptionInstance = new AdminDescription();
 
     var factory = angular.module('AdminDescriptionModule', []);
-    factory.constant('AdminDescription', new AdminDescription());
+    factory.constant('AdminDescription', adminDescriptionInstance);
 
-    var ngadmin = angular.module('ng-admin', ['main', 'crud', 'AdminDescriptionModule']);
+    var dataStore = angular.module('DataStoreModule', []);
+    dataStore.constant('DataStore', adminDescriptionInstance.getDataStore());
+
+    var ngadmin = angular.module('ng-admin', ['main', 'crud', 'AdminDescriptionModule', 'DataStoreModule']);
     ngadmin.config(function(NgAdminConfigurationProvider, AdminDescription) {
         NgAdminConfigurationProvider.setAdminDescription(AdminDescription);
     });

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -3,7 +3,7 @@
 define(function (require) {
     'use strict';
 
-    function maColumn($location, $anchorScroll, $compile, Configuration, FieldViewConfiguration) {
+    function maColumn($location, $anchorScroll, $compile, Configuration, DataStore, FieldViewConfiguration) {
 
         function isDetailLink(field) {
             if (field.isDetailLink() === false) {
@@ -26,6 +26,7 @@ define(function (require) {
                 entity: '&'
             },
             link: function(scope, element, attr) {
+                scope.DataStore = DataStore;
                 scope.field = scope.field();
                 scope.entry = scope.entry();
                 var type = scope.field.type();
@@ -62,7 +63,7 @@ define(function (require) {
         };
     }
 
-    maColumn.$inject = ['$location', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'FieldViewConfiguration'];
+    maColumn.$inject = ['$location', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'DataStore', 'FieldViewConfiguration'];
 
     return maColumn;
 });

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -23,10 +23,11 @@ define(function (require) {
             scope: {
                 field: '&',
                 entry: '&',
-                entity: '&'
+                entity: '&',
+                datastore: '&'
             },
             link: function(scope, element, attr) {
-                scope.DataStore = DataStore;
+                scope.datastore = scope.datastore();
                 scope.field = scope.field();
                 scope.entry = scope.entry();
                 var type = scope.field.type();

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -3,7 +3,7 @@
 define(function (require) {
     'use strict';
 
-    function maColumn($location, $anchorScroll, $compile, Configuration, DataStore, FieldViewConfiguration) {
+    function maColumn($location, $anchorScroll, $compile, Configuration, FieldViewConfiguration) {
 
         function isDetailLink(field) {
             if (field.isDetailLink() === false) {
@@ -64,7 +64,7 @@ define(function (require) {
         };
     }
 
-    maColumn.$inject = ['$location', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'DataStore', 'FieldViewConfiguration'];
+    maColumn.$inject = ['$location', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'FieldViewConfiguration'];
 
     return maColumn;
 });

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -49,6 +49,7 @@ define(function () {
         this.$location = undefined;
         this.DeleteQueries = undefined;
         this.view = undefined;
+        this.entity = undefined;
     };
 
     DeleteController.$inject = ['$scope', '$location', 'DeleteQueries', 'notification', 'params', 'view', 'entry'];

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -8,7 +8,7 @@ define(function (require) {
      *
      * @example <ma-choice-field entry="entry" field="field" value="value"></ma-choice-field>
      */
-    function maChoiceField(DataStore) {
+    function maChoiceField() {
         return {
             scope: {
                 'field': '&',
@@ -44,7 +44,7 @@ define(function (require) {
         };
     }
 
-    maChoiceField.$inject = ['DataStore'];
+    maChoiceField.$inject = [];
 
     return maChoiceField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -13,7 +13,8 @@ define(function (require) {
             scope: {
                 'field': '&',
                 'value': '=',
-                'entry':  '=?'
+                'entry':  '=?',
+                'datastore': '&?'
             },
             restrict: 'E',
             link: function(scope, element) {
@@ -22,7 +23,7 @@ define(function (require) {
                 scope.v = field.validation();
                 var choices;
                 if (field.type() === 'reference' || field.type() === 'reference_many') {
-                    choices = DataStore.getChoices(field);
+                    choices = scope.datastore().getChoices(field);
                 } else {
                     choices = field.choices();
                 }
@@ -33,7 +34,7 @@ define(function (require) {
                     select[name] = attributes[name];
                 }
             },
-            template: 
+            template:
 '<select ng-model="value" ng-required="v.required" id="{{ name }}" name="{{ name }}" class="form-control">' +
   '<option ng-if="!v.required" value="" ng-selected="!value">-- select a value --</option>' +
   '<option ng-repeat="choice in getChoices(entry)" value="{{ choice.value }}" ng-selected="value == choice.value">' +

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -8,7 +8,7 @@ define(function (require) {
      *
      * @example <ma-choice-field entry="entry" field="field" value="value"></ma-choice-field>
      */
-    function maChoiceField() {
+    function maChoiceField(DataStore) {
         return {
             scope: {
                 'field': '&',
@@ -20,7 +20,12 @@ define(function (require) {
                 var field = scope.field();
                 scope.name = field.name();
                 scope.v = field.validation();
-                var choices = field.choices();
+                var choices;
+                if (field.type() === 'reference' || field.type() === 'reference_many') {
+                    choices = DataStore.getChoices(field);
+                } else {
+                    choices = field.choices();
+                }
                 scope.getChoices = typeof(choices) === 'function' ? choices : function() { return choices; };
                 var select = element.children()[0];
                 var attributes = field.attributes();
@@ -38,7 +43,7 @@ define(function (require) {
         };
     }
 
-    maChoiceField.$inject = [];
+    maChoiceField.$inject = ['DataStore'];
 
     return maChoiceField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -8,7 +8,7 @@ define(function (require) {
      *
      * @example <ma-choices-field entry="entry" field="field" value="value"></ma-choices-field>
      */
-    function maChoicesField() {
+    function maChoicesField(DataStore) {
         return {
             scope: {
                 'field': '&',
@@ -20,7 +20,12 @@ define(function (require) {
                 var field = scope.field();
                 scope.name = field.name();
                 scope.v = field.validation();
-                var choices = field.choices();
+                var choices;
+                if (field.type() === 'reference' || field.type() === 'reference_many') {
+                    choices = DataStore.getChoices(field);
+                } else {
+                    choices = field.choices();
+                }
                 scope.getChoices = typeof(choices) === 'function' ? choices : function() { return choices; };
                 var select = element.children()[0];
                 var attributes = field.attributes();
@@ -50,7 +55,7 @@ define(function (require) {
         return false;
     }
 
-    maChoicesField.$inject = [];
+    maChoicesField.$inject = ['DataStore'];
 
     return maChoicesField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -13,7 +13,8 @@ define(function (require) {
             scope: {
                 'field': '&',
                 'value': '=',
-                'entry':  '=?'
+                'entry':  '=?',
+                'datastore': '&?'
             },
             restrict: 'E',
             link: function(scope, element) {
@@ -22,7 +23,7 @@ define(function (require) {
                 scope.v = field.validation();
                 var choices;
                 if (field.type() === 'reference' || field.type() === 'reference_many') {
-                    choices = DataStore.getChoices(field);
+                    choices = scope.datastore().getChoices(field);
                 } else {
                     choices = field.choices();
                 }

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -8,7 +8,7 @@ define(function (require) {
      *
      * @example <ma-choices-field entry="entry" field="field" value="value"></ma-choices-field>
      */
-    function maChoicesField(DataStore) {
+    function maChoicesField() {
         return {
             scope: {
                 'field': '&',
@@ -35,7 +35,7 @@ define(function (require) {
                 }
                 scope.contains = contains;
             },
-            template: 
+            template:
 '<select multiple ng-model="value" id="{{ name }}" name="{{ name }}" class="form-control" ng-required="v.required">' +
   '<option ng-repeat="choice in getChoices(entry)" value="{{ choice.value }}" ng-selected="contains(value, choice.value)">' +
     '{{ choice.label }}' +
@@ -56,7 +56,7 @@ define(function (require) {
         return false;
     }
 
-    maChoicesField.$inject = ['DataStore'];
+    maChoicesField.$inject = [];
 
     return maChoicesField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     var _ = require('lodash');
 
-    function maField(FieldViewConfiguration, DataStore) {
+    function maField(FieldViewConfiguration) {
         var writeWidgetTypes = _(FieldViewConfiguration)
             .map(function(fieldView, field) {
                 return '<span ng-switch-when="' + field + '">' + fieldView.getWriteWidget() +'</span>';
@@ -77,7 +77,7 @@ define(function (require) {
         };
     }
 
-    maField.$inject = ['FieldViewConfiguration', 'DataStore'];
+    maField.$inject = ['FieldViewConfiguration'];
 
     return maField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -5,7 +5,7 @@ define(function (require) {
 
     var _ = require('lodash');
 
-    function maField(FieldViewConfiguration) {
+    function maField(FieldViewConfiguration, DataStore) {
         var writeWidgetTypes = _(FieldViewConfiguration)
             .map(function(fieldView, field) {
                 return '<span ng-switch-when="' + field + '">' + fieldView.getWriteWidget() +'</span>';
@@ -33,11 +33,12 @@ define(function (require) {
                 entity: '&',
                 form: '&'
             },
-            link: function(scope, element, attr) {
+            link: function(scope) {
                 scope.field = scope.field();
                 scope.type = scope.field.type();
                 scope.entity = scope.entity();
                 scope.form = scope.form();
+                scope.DataStore = DataStore;
 
                 scope.getClassesForField = function(field, entry) {
                     return 'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');
@@ -75,7 +76,7 @@ define(function (require) {
         };
     }
 
-    maField.$inject = ['FieldViewConfiguration'];
+    maField.$inject = ['FieldViewConfiguration', 'DataStore'];
 
     return maField;
 });

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -10,7 +10,7 @@ define(function (require) {
             .map(function(fieldView, field) {
                 return '<span ng-switch-when="' + field + '">' + fieldView.getWriteWidget() +'</span>';
             }).join('');
-        var template = 
+        var template =
 '<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">' +
     '<label for="{{ field.name() }}" class="col-sm-2 control-label">' +
         '{{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;' +
@@ -21,7 +21,7 @@ define(function (require) {
     '</div>' +
     '<div ng-if="!field.editable()" ng-class="field.getCssClasses(entry)||\'col-sm-10\'">' +
         '<p class="form-control-static">' +
-            '<ma-column field="::field" entry="::entry" entity="::entity"></ma-column>' +
+            '<ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>' +
         '</p>' +
     '</div>' +
 '</div>';
@@ -31,14 +31,15 @@ define(function (require) {
                 field: '&',
                 entry: '=',
                 entity: '&',
-                form: '&'
+                form: '&',
+                'datastore': '&'
             },
             link: function(scope) {
                 scope.field = scope.field();
                 scope.type = scope.field.type();
                 scope.entity = scope.entity();
                 scope.form = scope.form();
-                scope.DataStore = DataStore;
+                scope.datastore = scope.datastore();
 
                 scope.getClassesForField = function(field, entry) {
                     return 'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -8,10 +8,10 @@ define(function(require) {
         return '<a ng-click="gotoReference()">' + getReadWidget() + '</a>';
     }
     function getFilterWidget() {
-        return '<ma-choice-field field="::field" value="values[field.name()]"></ma-choice-field>';
+        return '<ma-choice-field field="::field" value="values[field.name()]" datastore="::datastore"></ma-choice-field>';
     }
     function getWriteWidget() {
-        return '<ma-choice-field field="::field" value="entry.values[field.name()]"></ma-choice-field>';
+        return '<ma-choice-field field="::field" value="entry.values[field.name()]" datastore="::datastore"></ma-choice-field>';
     }
     return {
         getReadWidget:   getReadWidget,

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceManyFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceManyFieldView.js
@@ -8,10 +8,10 @@ define(function(require) {
         return '<ma-reference-many-link-column ids="::entry.values[field.name()]" values="::entry.listValues[field.name()]" field="::field"></ma-reference-many-link-column>';
     }
     function getFilterWidget() {
-        return '<ma-choices-field field="::field" value="values[field.name()]"></ma-choices-field>';
+        return '<ma-choices-field field="::field" value="values[field.name()]" datastore="::datastore"></ma-choices-field>';
     }
     function getWriteWidget() {
-        return '<ma-choices-field field="::field" value="entry.values[field.name()]"></ma-choices-field>';
+        return '<ma-choices-field field="::field" value="entry.values[field.name()]" datastore="::datastore"></ma-choices-field>';
     }
     return {
         getReadWidget:   getReadWidget,

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -3,7 +3,7 @@ define(function(require) {
 
     function getReadWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}" ' +
-                 'entries="::DataStore.getEntries(field.getReferencedView())" ' +
+                 'entries="::datastore.getEntries(field.targetEntity().uniqueId + \'_list\')" ' +
                  'fields="::field.getReferencedView().fields()" ' +
                  'list-actions="::field.listActions()" ' +
                  'entity="::field.getReferencedView().entity">' +
@@ -17,7 +17,7 @@ define(function(require) {
     }
     function getWriteWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}"' +
-                  'entries="::DataStore.getEntries(field.getReferencedView())" ' +
+                  'entries="::datastore.getEntries(field.targetEntity().uniqueId + \'_list\')" ' +
                   'fields="::field.getReferencedView().fields()" ' +
                   'list-actions="::field.listActions()" ' +
                   'entity="::field.getReferencedView().entity">' +

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -3,7 +3,7 @@ define(function(require) {
 
     function getReadWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}" ' +
-                 'entries="::field.getReferencedView().getReferencesEntries()" ' +
+                 'entries="::DataStore.getEntries(field.getReferencedView())" ' +
                  'fields="::field.getReferencedView().fields()" ' +
                  'list-actions="::field.listActions()" ' +
                  'entity="::field.getReferencedView().entity">' +
@@ -17,7 +17,7 @@ define(function(require) {
     }
     function getWriteWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}"' +
-                  'entries="::field.getReferencedView().getReferencesEntries()" ' +
+                  'entries="::DataStore.getEntries(field.getReferencedView())" ' +
                   'fields="::field.getReferencedView().fields()" ' +
                   'list-actions="::field.listActions()" ' +
                   'entity="::field.getReferencedView().entity">' +

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -3,7 +3,7 @@ define(function(require) {
 
     function getReadWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}" ' +
-                 'entries="field.entries" ' +
+                 'entries="::field.getReferencedView().getReferencesEntries()" ' +
                  'fields="::field.getReferencedView().fields()" ' +
                  'list-actions="::field.listActions()" ' +
                  'entity="::field.getReferencedView().entity">' +
@@ -17,7 +17,7 @@ define(function(require) {
     }
     function getWriteWidget() {
         return '<ma-datagrid name="{{ field.getReferencedView().name() }}"' +
-                  'entries="field.entries" ' +
+                  'entries="::field.getReferencedView().getReferencesEntries()" ' +
                   'fields="::field.getReferencedView().fields()" ' +
                   'list-actions="::field.listActions()" ' +
                   'entity="::field.getReferencedView().entity">' +
@@ -28,5 +28,5 @@ define(function(require) {
         getLinkWidget:   getLinkWidget,
         getFilterWidget: getFilterWidget,
         getWriteWidget:  getWriteWidget,
-    }
+    };
 });

--- a/src/javascripts/ng-admin/Crud/filter/maFilter.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilter.js
@@ -28,7 +28,8 @@ define(function (require) {
             restrict: 'E',
             template: template,
             scope: {
-                filters: '&'
+                filters: '&',
+                datastore: '&'
             },
             controllerAs: 'filterCtrl',
             controller: FilterController

--- a/src/javascripts/ng-admin/Crud/filter/maFilterController.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilterController.js
@@ -64,6 +64,10 @@ define(function () {
         this.filter();
     };
 
+    maFilterController.prototype.destroy = function () {
+        this.$scope = undefined;
+    };
+
     maFilterController.$inject = ['$scope', '$state', '$stateParams'];
 
     return maFilterController;

--- a/src/javascripts/ng-admin/Crud/filter/maFilterController.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilterController.js
@@ -18,6 +18,7 @@ define(function () {
         this.$stateParams = $stateParams;
         this.$scope.values = this.$stateParams.search || {};
         this.$scope.filters = this.$scope.filters();
+        this.$scope.datastore = this.$scope.datastore();
         this.isFilterEmpty = isEmpty(this.$scope.values);
     }
 

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -3,13 +3,14 @@
 define(function () {
     'use strict';
 
-    var FormController = function ($scope, $state, CreateQueries, UpdateQueries, Validator, Configuration,
+    var FormController = function ($scope, $state, CreateQueries, UpdateQueries, DataStore, Validator, Configuration,
                                    progression, notification, view, entry) {
 
         this.$scope = $scope;
         this.$state = $state;
         this.CreateQueries = CreateQueries;
         this.UpdateQueries = UpdateQueries;
+        this.DataStore = DataStore;
         this.Validator = Validator;
         this.progression = progression;
         this.notification = notification;
@@ -55,7 +56,7 @@ define(function () {
             object[field.name()] = value;
         }
 
-        mappedObject = this.view.mapEntry(object);
+        mappedObject = this.DataStore.mapEntry(this.view, object);
 
         try {
             this.Validator.validate(this.view, mappedObject);
@@ -123,11 +124,12 @@ define(function () {
         this.$state = undefined;
         this.CreateQueries = undefined;
         this.UpdateQueries = undefined;
+        this.DataStore = undefined;
         this.view = undefined;
         this.entity = undefined;
     };
 
-    FormController.$inject = ['$scope', '$state', 'CreateQueries', 'UpdateQueries', 'Validator', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'entry'];
+    FormController.$inject = ['$scope', '$state', 'CreateQueries', 'UpdateQueries', 'DataStore', 'Validator', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'entry'];
 
     return FormController;
 });

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -3,14 +3,14 @@
 define(function () {
     'use strict';
 
-    var FormController = function ($scope, $state, CreateQueries, UpdateQueries, DataStore, Validator, Configuration,
-                                   progression, notification, view, entry) {
+    var FormController = function ($scope, $state, CreateQueries, UpdateQueries, Validator, Configuration,
+                                   progression, notification, view, dataStore) {
 
         this.$scope = $scope;
         this.$state = $state;
         this.CreateQueries = CreateQueries;
         this.UpdateQueries = UpdateQueries;
-        this.DataStore = DataStore;
+        this.dataStore = dataStore;
         this.Validator = Validator;
         this.progression = progression;
         this.notification = notification;
@@ -21,12 +21,12 @@ define(function () {
         this.config = Configuration();
         this.view = view;
         this.entity = this.view.getEntity();
-        this.$scope.entry = entry;
+        this.$scope.entry = dataStore.getFirstEntry(this.entity.uniqueId);
         this.$scope.view = view;
         this.$scope.entity = this.entity;
 
         // in case of entity identifier being modified
-        this.originEntityId = entry.values[this.entity.identifier().name()];
+        this.originEntityId = this.$scope.entry.values[this.entity.identifier().name()];
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };
@@ -56,7 +56,12 @@ define(function () {
             object[field.name()] = value;
         }
 
-        mappedObject = this.DataStore.mapEntry(this.view, object);
+        mappedObject = this.dataStore.mapEntry(
+            this.view.entity.name(),
+            this.view.identifier(),
+            this.view.getFields(),
+            object
+        );
 
         try {
             this.Validator.validate(this.view, mappedObject);
@@ -71,23 +76,23 @@ define(function () {
     FormController.prototype.submitCreation = function ($event) {
         $event.preventDefault();
         var entry = this.validateEntry();
-        var entity = this.$scope.entity;
+        var entity = this.entity;
         var route = !entity.editionView().enabled ? 'show' : 'edit';
         if (!entry) {
             return;
         }
         var progression = this.progression,
             notification = this.notification,
-            entity = this.entity,
             $state = this.$state;
         progression.start();
         this.CreateQueries
             .createOne(this.view, entry)
-            .then(function (response) {
+            .then(function (rawEntry) {
+                var entry = this.dataStore.mapEntry(entity.name(), this.view.identifier(), this.view.getFields(), rawEntry);
                 progression.done();
                 notification.log('Element successfully created.', {addnCls: 'humane-flatty-success'});
-                $state.go($state.get(route), { entity: entity.name(), id: response.identifierValue });
-            }, this.handleError.bind(this));
+                $state.go($state.get(route), { entity: entity.name(), id: entry.identifierValue });
+            }.bind(this), this.handleError.bind(this));
     };
 
     FormController.prototype.submitEdition = function ($event) {
@@ -124,12 +129,12 @@ define(function () {
         this.$state = undefined;
         this.CreateQueries = undefined;
         this.UpdateQueries = undefined;
-        this.DataStore = undefined;
+        this.dataStore = undefined;
         this.view = undefined;
         this.entity = undefined;
     };
 
-    FormController.$inject = ['$scope', '$state', 'CreateQueries', 'UpdateQueries', 'DataStore', 'Validator', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'entry'];
+    FormController.$inject = ['$scope', '$state', 'CreateQueries', 'UpdateQueries', 'Validator', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'dataStore'];
 
     return FormController;
 });

--- a/src/javascripts/ng-admin/Crud/form/create.html
+++ b/src/javascripts/ng-admin/Crud/form/create.html
@@ -16,7 +16,7 @@
 <div class="row" id="create-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitCreation($event)">
         <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form"></ma-field>
+            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
         </div>
 
         <div class="form-group">

--- a/src/javascripts/ng-admin/Crud/form/edit.html
+++ b/src/javascripts/ng-admin/Crud/form/edit.html
@@ -17,7 +17,7 @@
 <div class="row" id="edit-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitEdition($event)">
         <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form"></ma-field>
+            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
         </div>
 
         <div class="form-group">

--- a/src/javascripts/ng-admin/Crud/list/ListController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListController.js
@@ -3,7 +3,7 @@
 define(function () {
     'use strict';
 
-    var ListController = function ($scope, $stateParams, $filter, $location, $anchorScroll, RetrieveQueries, progression, view, data) {
+    var ListController = function ($scope, $stateParams, $filter, $location, $anchorScroll, RetrieveQueries, progression, view, dataStore, totalItems) {
         this.$scope = $scope;
         this.$stateParams = $stateParams;
         this.$filter = $filter;
@@ -20,10 +20,10 @@ define(function () {
         this.loadingPage = false;
         this.filters = this.$filter('orderElement')(view.filters());
         this.hasFilters = Object.keys(this.filters).length > 0;
-        this.entries = data.entries;
+        this.dataStore = dataStore;
         this.fields = view.fields();
         this.listActions = view.listActions();
-        this.totalItems = data.totalItems;
+        this.totalItems = totalItems;
         this.page = $stateParams.page || 1;
         this.infinitePagination = this.view.infinitePagination();
         this.nextPageCallback = this.nextPage.bind(this);
@@ -69,7 +69,7 @@ define(function () {
         this.$anchorScroll = undefined;
     };
 
-    ListController.$inject = ['$scope', '$stateParams', '$filter', '$location', '$anchorScroll', 'RetrieveQueries', 'progression', 'view', 'data'];
+    ListController.$inject = ['$scope', '$stateParams', '$filter', '$location', '$anchorScroll', 'RetrieveQueries', 'progression', 'view', 'dataStore', 'totalItems'];
 
     return ListController;
 });

--- a/src/javascripts/ng-admin/Crud/list/ListController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListController.js
@@ -67,6 +67,7 @@ define(function () {
         this.$filter = undefined;
         this.$location = undefined;
         this.$anchorScroll = undefined;
+        this.dataStore = undefined;
     };
 
     ListController.$inject = ['$scope', '$stateParams', '$filter', '$location', '$anchorScroll', 'RetrieveQueries', 'progression', 'view', 'dataStore', 'totalItems'];

--- a/src/javascripts/ng-admin/Crud/list/list.html
+++ b/src/javascripts/ng-admin/Crud/list/list.html
@@ -13,14 +13,15 @@
             <p class="lead" ng-if="::listController.description" compile="::listController.description">{{ ::listController.description }}</p>
         </div>
 
-        <ma-filter ng-if="listController.hasFilters" filters="::listController.filters"></ma-filter>
+        <ma-filter ng-if="listController.hasFilters" filters="::listController.filters" datastore="::listController.dataStore"></ma-filter>
     </div>
 </div>
 
 <div class="row list-view" ng-class="::'ng-admin-entity-' + listController.entity.name()">
     <div class="col-lg-12">
         <ma-datagrid name="{{ ::listController.view.name() }}"
-                  entries="listController.entries"
+                  entries="listController.dataStore.getEntries(listController.entity.uniqueId)"
+                  datastore="listController.dataStore"
                   selection="listController.selection"
                   fields="::listController.fields"
                   list-actions="::listController.listActions"

--- a/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
@@ -24,15 +24,17 @@ define(function (require) {
      * @returns {promise}  the new object
      */
     CreateQueries.prototype.createOne = function (view, rawEntity) {
+        var self = this;
+
         return this.Restangular
             .oneUrl(view.entity.name(), this.config.getRouteFor(view))
             .customPOST(rawEntity)
             .then(function (response) {
-                return view.mapEntry(response.data);
+                return self.DataStore.mapEntry(view, response.data);
             });
     };
 
-    CreateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
+    CreateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
 
     return CreateQueries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
@@ -24,17 +24,15 @@ define(function (require) {
      * @returns {promise}  the new object
      */
     CreateQueries.prototype.createOne = function (view, rawEntity) {
-        var self = this;
-
         return this.Restangular
             .oneUrl(view.entity.name(), this.config.getRouteFor(view))
             .customPOST(rawEntity)
             .then(function (response) {
-                return self.DataStore.mapEntry(view, response.data);
+                return response.data;
             });
     };
 
-    CreateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
+    CreateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
 
     return CreateQueries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/DeleteQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/DeleteQueries.js
@@ -47,7 +47,7 @@ define(function (require) {
         return this.$q.all(promises);
     };
 
-    DeleteQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
+    DeleteQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
 
     return DeleteQueries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/DeleteQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/DeleteQueries.js
@@ -47,7 +47,7 @@ define(function (require) {
         return this.$q.all(promises);
     };
 
-    DeleteQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
+    DeleteQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
 
     return DeleteQueries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/Queries.js
+++ b/src/javascripts/ng-admin/Crud/repository/Queries.js
@@ -10,17 +10,16 @@ define(function () {
      * @param {Application} Configuration
      * @constructor
      */
-    function Queries($q, Restangular, Configuration, DataStore, PromisesResolver) {
+    function Queries($q, Restangular, Configuration, PromisesResolver) {
         this.$q = $q;
         this.Restangular = Restangular;
         this.config = Configuration();
-        this.DataStore = DataStore;
         this.PromisesResolver = PromisesResolver;
 
         this.Restangular.setFullResponse(true);  // To get also the headers
     }
 
-    Queries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
+    Queries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
 
     return Queries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/Queries.js
+++ b/src/javascripts/ng-admin/Crud/repository/Queries.js
@@ -10,16 +10,17 @@ define(function () {
      * @param {Application} Configuration
      * @constructor
      */
-    function Queries($q, Restangular, Configuration, PromisesResolver) {
+    function Queries($q, Restangular, Configuration, DataStore, PromisesResolver) {
         this.$q = $q;
         this.Restangular = Restangular;
         this.config = Configuration();
+        this.DataStore = DataStore;
         this.PromisesResolver = PromisesResolver;
 
         this.Restangular.setFullResponse(true);  // To get also the headers
     }
 
-    Queries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
+    Queries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
 
     return Queries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
@@ -16,7 +16,7 @@ define(function (require) {
     utils.inherits(RetrieveQueries, Queries);
 
     /**
-     * Get one entity (!!!!! NOT MAPPED !!!!!!)
+     * Get one entity
      *
      * @param {View}   view      the edit view associated to the entity
      * @param {Number} entityId  id of the entity
@@ -195,8 +195,6 @@ define(function (require) {
                         continue;
                     }
 
-                    // Entry are already mapped by getOne (should not be done in the getOne !!!!)
-                    // TODO: read comment above !!!!
                     referencedData[reference.name()] = datas;
                 }
 

--- a/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
@@ -179,6 +179,7 @@ define(function (require) {
 
                     reference = referencedValues[j];
                     singleCallFilters = reference.getSingleApiCall(identifiers);
+                    referencedView = reference.getReferencedView();
 
                     // Retrieve entries depending on 1 or many request was done
                     if (singleCallFilters || !rawValues) {
@@ -187,7 +188,7 @@ define(function (require) {
                             // the response failed
                             continue;
                         }
-                        referencedValues[j].entries = reference.getReferencedView().mapEntries(response.result.data);
+                        referencedView.setReferences(referencedView.mapEntries(response.result.data));
                     } else {
                         entries = [];
                         identifiers = reference.getIdentifierValues(rawValues);
@@ -201,7 +202,7 @@ define(function (require) {
                         }
 
                         // Entry are already mapped by getOne
-                        referencedValues[j].entries = entries;
+                        referencedView.setReferences(entries);
                     }
                 }
 
@@ -224,7 +225,7 @@ define(function (require) {
             referencedLists = view.getReferencedLists(),
             calls = [],
             referencedList,
-            referencedView,
+            referencedListView,
             filter,
             i,
             j;
@@ -233,8 +234,8 @@ define(function (require) {
             referencedList = referencedLists[i];
             filter = {};
             filter[referencedList.targetReferenceField()] = entityId;
-            referencedView = referencedList.getReferencedView();
-            calls.push(self.getRawValues(referencedView, 1, filter, sortField || (referencedView.name() + '.' + referencedList.sortField()), sortDir || referencedList.sortDir()));
+            referencedListView = referencedList.getReferencedView();
+            calls.push(self.getRawValues(referencedListView, 1, filter, sortField || (referencedListView.name() + '.' + referencedList.sortField()), sortDir || referencedList.sortDir()));
         }
 
         return this.$q.all(calls)
@@ -243,9 +244,10 @@ define(function (require) {
 
                 for (i in referencedLists) {
                     referencedList = referencedLists[i];
+                    referencedListView = referencedList.getReferencedView();
 
                     // Map entries
-                    referencedList.entries = referencedList.getReferencedView().mapEntries(responses[j++].data);
+                    referencedListView.setReferences(referencedListView.mapEntries(responses[j++].data));
                 }
 
                 return referencedLists;

--- a/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/RetrieveQueries.js
@@ -121,7 +121,7 @@ define(function (require) {
             identifiers,
             reference,
             referencedView,
-            datas,
+            data,
             i,
             j,
             k;
@@ -180,7 +180,7 @@ define(function (require) {
                         continue;
                     }
 
-                    datas = [];
+                    data = [];
                     identifiers = reference.getIdentifierValues(rawValues);
                     for (k in identifiers) {
                         response = responses[i++];
@@ -188,14 +188,14 @@ define(function (require) {
                             // one of the responses failed
                             continue;
                         }
-                        datas.push(response.result);
+                        data.push(response.result);
                     }
 
-                    if (!datas.length) {
+                    if (!data.length) {
                         continue;
                     }
 
-                    referencedData[reference.name()] = datas;
+                    referencedData[reference.name()] = data;
                 }
 
                 return referencedData;

--- a/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
@@ -26,17 +26,18 @@ define(function (require) {
      */
     UpdateQueries.prototype.updateOne = function (view, rawEntity, originEntityId) {
         var entityId = originEntityId || rawEntity[view.getEntity().identifier().name()];
+        var self = this;
 
         // Get element data
         return this.Restangular
             .oneUrl(view.entity.name(), this.config.getRouteFor(view, entityId))
             .customPUT(rawEntity)
             .then(function (response) {
-                return view.mapEntry(response.data);
+                return self.DataStore.mapEntry(view, response.data);
             });
     };
 
-    UpdateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
+    UpdateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
 
     return UpdateQueries;
 });

--- a/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
@@ -26,18 +26,17 @@ define(function (require) {
      */
     UpdateQueries.prototype.updateOne = function (view, rawEntity, originEntityId) {
         var entityId = originEntityId || rawEntity[view.getEntity().identifier().name()];
-        var self = this;
 
         // Get element data
         return this.Restangular
             .oneUrl(view.entity.name(), this.config.getRouteFor(view, entityId))
             .customPUT(rawEntity)
             .then(function (response) {
-                return self.DataStore.mapEntry(view, response.data);
+                return response.data;
             });
     };
 
-    UpdateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'DataStore', 'PromisesResolver'];
+    UpdateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];
 
     return UpdateQueries;
 });

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -24,8 +24,9 @@ define(function (require) {
 
     function viewProvider(viewName) {
         return ['$stateParams', 'NgAdminConfiguration', function ($stateParams, Configuration) {
+            var view;
             try {
-                var view = Configuration().getViewByEntityAndType($stateParams.entity, viewName);
+                view = Configuration().getViewByEntityAndType($stateParams.entity, viewName);
             } catch (e) {
                 var error404 = new Error('Unknown view or entity name');
                 error404.status = 404; // trigger the 404 error
@@ -97,8 +98,8 @@ define(function (require) {
 
                         return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, rawEntry.identifierValue);
                     }],
-                    entry: ['RetrieveQueries', 'rawEntry', 'referencedValues', function(RetrieveQueries, rawEntry, referencedValues) {
-                        return RetrieveQueries.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
+                    entry: ['DataStore', 'rawEntry', 'referencedValues', function(DataStore, rawEntry, referencedValues) {
+                        return DataStore.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
                     }]
                 }
             });
@@ -112,14 +113,8 @@ define(function (require) {
                 templateProvider: templateProvider('CreateView', createTemplate),
                 resolve: {
                     view: viewProvider('CreateView'),
-                    entry: ['view', function (view) {
-                        var entry = view
-                            .mapEntry({});
-
-                        view.processFieldsDefaultValue(entry);
-                        view.setEntry(entry);
-
-                        return entry;
+                    entry: ['DataStore', 'view', function (DataStore, view) {
+                        return DataStore.createEntry(view);
                     }],
                     referencedValues: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
                         return RetrieveQueries.getReferencedValues(view.getReferences());
@@ -145,8 +140,8 @@ define(function (require) {
                     rawEntry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', 'rawEntry', function (RetrieveQueries, view, rawEntry) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences(), null);
+                    referencedValues: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
+                        return RetrieveQueries.getReferencedValues(view.getReferences());
                     }],
                     referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
                         var sortField = $stateParams.sortField,
@@ -154,8 +149,8 @@ define(function (require) {
 
                         return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, rawEntry.identifierValue);
                     }],
-                    entry: ['RetrieveQueries', 'rawEntry', 'referencedValues', function(RetrieveQueries, rawEntry, referencedValues) {
-                        return RetrieveQueries.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
+                    entry: ['DataStore', 'rawEntry', 'referencedValues', function(DataStore, rawEntry, referencedValues) {
+                        return DataStore.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
                     }]
                 }
             });

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -117,6 +117,7 @@ define(function (require) {
                             .mapEntry({});
 
                         view.processFieldsDefaultValue(entry);
+                        view.setEntry(entry);
 
                         return entry;
                     }],

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -39,6 +39,12 @@ define(function (require) {
         }];
     }
 
+    function dataStoreProvider() {
+        return ['AdminDescription', function (AdminDescription) {
+            return AdminDescription.getDataStore();
+        }];
+    }
+
     function routing($stateProvider) {
 
         $stateProvider
@@ -56,17 +62,83 @@ define(function (require) {
                 controllerAs: 'listController',
                 templateProvider: templateProvider('ListView', listTemplate),
                 resolve: {
+                    dataStore: dataStoreProvider(),
                     view: viewProvider('ListView'),
-                    data: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
+                    response: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         var page = $stateParams.page,
                             filters = $stateParams.search,
                             sortField = $stateParams.sortField,
                             sortDir = $stateParams.sortDir;
 
-                        return RetrieveQueries.getAll(view, page, true, filters, sortField, sortDir);
+                        return RetrieveQueries.getAll(view, page, filters, sortField, sortDir);
                     }],
-                    referencedValues: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
-                        return RetrieveQueries.getReferencedValues(view.getFilterReferences());
+                    totalItems: ['response', function (response) {
+                        return response.totalItems;
+                    }],
+                    referencedData: ['RetrieveQueries', 'view', 'response', function (RetrieveQueries, view, response) {
+                        return RetrieveQueries.getReferencedData(view.getReferences(), response.data);
+                    }],
+                    referencedEntries: ['dataStore', 'view', 'referencedData', function (dataStore, view, referencedData) {
+                        var references = view.getReferences();
+                        var referencedEntries;
+
+                        for (var name in referencedData) {
+                            referencedEntries = dataStore.mapEntries(
+                                references[name].targetEntity().name(),
+                                references[name].targetEntity().identifier(),
+                                [references[name].targetField()],
+                                referencedData[name]
+                            );
+
+                            dataStore.setEntries(
+                                references[name].targetEntity().uniqueId + '_values',
+                                referencedEntries
+                            );
+                        }
+
+                        return true;
+                    }],
+                    entries: ['dataStore', 'view', 'response', 'referencedEntries', function (dataStore, view, response, referencedEntries) {
+                        var entries = dataStore.mapEntries(
+                            view.entity.name(),
+                            view.identifier(),
+                            view.getFields(),
+                            response.data
+                        );
+
+                        // shortcut to diplay collection of entry with included referenced values
+                        dataStore.fillReferencesValuesFromCollection(entries, view.getReferences(), true);
+
+                        // set entries here ???
+                        dataStore.setEntries(
+                            view.getEntity().uniqueId,
+                            entries
+                        );
+
+                        return true;
+                    }],
+                    filterData: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
+                        return RetrieveQueries.getReferencedData(view.getFilterReferences());
+                    }],
+                    filterEntries: ['dataStore', 'view', 'filterData', function (dataStore, view, filterData) {
+                        var filters = view.getFilterReferences();
+                        var filterEntries;
+
+                        for (var name in filterData) {
+                            filterEntries = dataStore.mapEntries(
+                                filters[name].targetEntity().name(),
+                                filters[name].targetEntity().identifier(),
+                                [filters[name].targetField()],
+                                filterData[name]
+                            );
+
+                            dataStore.setEntries(
+                                filters[name].targetEntity().uniqueId + '_choices',
+                                filterEntries
+                            );
+                        }
+
+                        return true;
                     }]
                 }
             });
@@ -85,21 +157,76 @@ define(function (require) {
                     sortDir: null
                 },
                 resolve: {
+                    dataStore: dataStoreProvider(),
                     view: viewProvider('ShowView'),
                     rawEntry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', 'rawEntry', function (RetrieveQueries, view, rawEntry) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences(), [rawEntry.values]);
+                    entry: ['dataStore', 'view', 'rawEntry', function(dataStore, view, rawEntry) {
+                        return dataStore.mapEntry(
+                            view.entity.name(),
+                            view.identifier(),
+                            view.getFields(),
+                            rawEntry
+                        );
                     }],
-                    referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
-                        var sortField = $stateParams.sortField,
-                            sortDir = $stateParams.sortDir;
+                    referencedData: ['RetrieveQueries', 'view', 'entry', function (RetrieveQueries, view, entry) {
+                        return RetrieveQueries.getReferencedData(view.getReferences(), [entry.values]);
+                    }],
+                    referencedEntries: ['dataStore', 'view', 'referencedData', function (dataStore, view, referencedData) {
+                        var references = view.getReferences();
+                        var referencedEntries;
 
-                        return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, rawEntry.identifierValue);
+                        for (var name in referencedData) {
+                            referencedEntries = dataStore.mapEntries(
+                                references[name].targetEntity().name(),
+                                references[name].targetEntity().identifier(),
+                                [references[name].targetField()],
+                                referencedData[name]
+                            );
+
+                            dataStore.setEntries(
+                                references[name].targetEntity().uniqueId + '_values',
+                                referencedEntries
+                            );
+                        }
+
+                        return true;
                     }],
-                    entry: ['DataStore', 'rawEntry', 'referencedValues', function(DataStore, rawEntry, referencedValues) {
-                        return DataStore.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
+                    referencedListData: ['$stateParams', 'RetrieveQueries', 'view', 'entry', function ($stateParams, RetrieveQueries, view, entry) {
+                        var referencedLists = view.getReferencedLists();
+                        var sortField = $stateParams.sortField;
+                        var sortDir = $stateParams.sortDir;
+
+                        return RetrieveQueries.getReferencedListData(referencedLists, sortField, sortDir, entry.identifierValue);
+                    }],
+                    referencedListEntries: ['dataStore', 'view', 'referencedListData', function (dataStore, view, referencedListData) {
+                        var referencedLists = view.getReferencedLists();
+                        var referencedList;
+                        var referencedListEntries;
+
+                        for (var i in referencedLists) {
+                            referencedList = referencedLists[i];
+                            referencedListEntries = referencedListData[i];
+
+                            referencedListEntries = dataStore.mapEntries(
+                                referencedList.targetEntity().name(),
+                                referencedList.targetEntity().identifier(),
+                                referencedList.targetFields(),
+                                referencedListEntries
+                            );
+
+                            dataStore.setEntries(
+                                referencedList.targetEntity().uniqueId + '_list',
+                                referencedListEntries
+                            );
+                        }
+                    }],
+                    entryWithReferences: ['dataStore', 'view', 'entry', 'referencedEntries', function(dataStore, view, entry, referencedEntries) {
+                        dataStore.fillReferencesValuesFromEntry(entry, view.getReferences(), true);
+
+                        dataStore.addEntry(view.getEntity().uniqueId, entry);
+                        return true;
                     }]
                 }
             });
@@ -112,12 +239,36 @@ define(function (require) {
                 controllerAs: 'formController',
                 templateProvider: templateProvider('CreateView', createTemplate),
                 resolve: {
+                    dataStore: dataStoreProvider(),
                     view: viewProvider('CreateView'),
-                    entry: ['DataStore', 'view', function (DataStore, view) {
-                        return DataStore.createEntry(view);
+                    entry: ['dataStore', 'view', function (dataStore, view) {
+                        var entry = dataStore.createEntry(view.entity.name(), view.identifier(), view.getFields());
+                        dataStore.addEntry(view.getEntity().uniqueId, entry);
+
+                        return entry;
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences());
+                    referencedData: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
+                        return RetrieveQueries.getReferencedData(view.getReferences());
+                    }],
+                    referencedEntries: ['dataStore', 'view', 'referencedData', function (dataStore, view, referencedData) {
+                        var references = view.getReferences();
+                        var referencedEntries;
+
+                        for (var name in referencedData) {
+                            referencedEntries = dataStore.mapEntries(
+                                references[name].targetEntity().name(),
+                                references[name].targetEntity().identifier(),
+                                [references[name].targetField()],
+                                referencedData[name]
+                            );
+
+                            dataStore.setEntries(
+                                references[name].targetEntity().uniqueId + '_choices',
+                                referencedEntries
+                            );
+                        }
+
+                        return true;
                     }]
                 }
             });
@@ -136,21 +287,76 @@ define(function (require) {
                     sortDir: null
                 },
                 resolve: {
+                    dataStore: dataStoreProvider(),
                     view: viewProvider('EditView'),
                     rawEntry: ['$stateParams', 'RetrieveQueries', 'view', function ($stateParams, RetrieveQueries, view) {
                         return RetrieveQueries.getOne(view, $stateParams.id);
                     }],
-                    referencedValues: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
-                        return RetrieveQueries.getReferencedValues(view.getReferences());
+                    entry: ['dataStore', 'view', 'rawEntry', function(dataStore, view, rawEntry) {
+                        return dataStore.mapEntry(
+                            view.entity.name(),
+                            view.identifier(),
+                            view.getFields(),
+                            rawEntry
+                        );
                     }],
-                    referencedListValues: ['$stateParams', 'RetrieveQueries', 'view', 'rawEntry', function ($stateParams, RetrieveQueries, view, rawEntry) {
-                        var sortField = $stateParams.sortField,
-                            sortDir = $stateParams.sortDir;
+                    referencedData: ['RetrieveQueries', 'view', function (RetrieveQueries, view) {
+                        return RetrieveQueries.getReferencedData(view.getReferences());
+                    }],
+                    referencedEntries: ['dataStore', 'view', 'referencedData', function (dataStore, view, referencedData) {
+                        var references = view.getReferences();
 
-                        return RetrieveQueries.getReferencedListValues(view, sortField, sortDir, rawEntry.identifierValue);
+                        var referencedEntries;
+                        for (var name in referencedData) {
+                            referencedEntries = dataStore.mapEntries(
+                                references[name].targetEntity().name(),
+                                references[name].targetEntity().identifier(),
+                                [references[name].targetField()],
+                                referencedData[name]
+                            );
+
+                            dataStore.setEntries(
+                                references[name].targetEntity().uniqueId + '_choices',
+                                referencedEntries
+                            );
+                        }
+
+                        return true;
                     }],
-                    entry: ['DataStore', 'rawEntry', 'referencedValues', function(DataStore, rawEntry, referencedValues) {
-                        return DataStore.fillReferencesValuesFromEntry(rawEntry, referencedValues, true);
+                    referencedListData: ['$stateParams', 'RetrieveQueries', 'view', 'entry', function ($stateParams, RetrieveQueries, view, entry) {
+                        var referencedLists = view.getReferencedLists();
+                        var sortField = $stateParams.sortField;
+                        var sortDir = $stateParams.sortDir;
+
+                        return RetrieveQueries.getReferencedListData(referencedLists, sortField, sortDir, entry.identifierValue);
+                    }],
+                    referencedListEntries: ['dataStore', 'view', 'referencedListData', function (dataStore, view, referencedListData) {
+                        var referencedLists = view.getReferencedLists();
+                        var referencedList;
+                        var referencedListEntries;
+
+                        for (var i in referencedLists) {
+                            referencedList = referencedLists[i];
+                            referencedListEntries = referencedListData[i];
+
+                            referencedListEntries = dataStore.mapEntries(
+                                referencedList.targetEntity().name(),
+                                referencedList.targetEntity().identifier(),
+                                referencedList.targetFields(),
+                                referencedListEntries
+                            );
+
+                            dataStore.setEntries(
+                                referencedList.targetEntity().uniqueId + '_list',
+                                referencedListEntries
+                            );
+                        }
+                    }],
+                    entryWithReferences: ['dataStore', 'view', 'entry', 'referencedEntries', function(dataStore, view, entry, referencedEntries) {
+                        dataStore.fillReferencesValuesFromEntry(entry, view.getReferences(), true);
+
+                        dataStore.addEntry(view.getEntity().uniqueId, entry);
+                        return true;
                     }]
                 }
             });

--- a/src/javascripts/ng-admin/Crud/show/ShowController.js
+++ b/src/javascripts/ng-admin/Crud/show/ShowController.js
@@ -3,7 +3,7 @@
 define(function () {
     'use strict';
 
-    var ShowController = function ($scope, $location, view, entry) {
+    var ShowController = function ($scope, $location, view, dataStore) {
         this.$scope = $scope;
         this.$location = $location;
         this.title = view.title();
@@ -11,10 +11,11 @@ define(function () {
         this.actions = view.actions();
 
         this.fields = view.fields();
-        this.$scope.entry = entry;
+        this.$scope.entry = dataStore.getFirstEntry(view.getEntity().uniqueId);
         this.$scope.view = view;
         this.view = view;
         this.entity = this.view.getEntity();
+        this.dataStore = dataStore;
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };
@@ -26,7 +27,7 @@ define(function () {
         this.entity = undefined;
     };
 
-    ShowController.$inject = ['$scope', '$location', 'view', 'entry'];
+    ShowController.$inject = ['$scope', '$location', 'view', 'dataStore'];
 
     return ShowController;
 });

--- a/src/javascripts/ng-admin/Crud/show/ShowController.js
+++ b/src/javascripts/ng-admin/Crud/show/ShowController.js
@@ -25,6 +25,7 @@ define(function () {
         this.$location = undefined;
         this.view = undefined;
         this.entity = undefined;
+        this.dataStore = undefined;
     };
 
     ShowController.$inject = ['$scope', '$location', 'view', 'dataStore'];

--- a/src/javascripts/ng-admin/Crud/show/show.html
+++ b/src/javascripts/ng-admin/Crud/show/show.html
@@ -24,7 +24,7 @@
 
         <div class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
 
-            <ma-column field="::field" entry="::entry" entity="::entity"></ma-column>
+            <ma-column field="::field" entry="::entry" entity="::entity" datastore="::showController.dataStore"></ma-column>
 
         </div>
     </div>

--- a/src/javascripts/ng-admin/Main/component/controller/DashboardController.js
+++ b/src/javascripts/ng-admin/Main/component/controller/DashboardController.js
@@ -29,7 +29,7 @@ define(function (require) {
         this.panels = [];
 
         this.PanelBuilder.getPanelsData().then(function (panels) {
-            self.panels = panels
+            self.panels = panels;
         });
     };
 

--- a/src/javascripts/ng-admin/es6/lib/DataStore/DataStore.js
+++ b/src/javascripts/ng-admin/es6/lib/DataStore/DataStore.js
@@ -1,0 +1,50 @@
+
+class DataStore {
+    constructor(name) {
+        this._name = name;
+        this._entry = new Map();
+        this._entries = new Map();
+        this._references = new Map();
+    }
+
+    name() {
+        if (arguments.length) {
+            this._name = arguments[0];
+            return this;
+        }
+
+        return this._name;
+    }
+
+    setEntry(view, entry) {
+        this._entry.set(view, entry);
+
+        return this;
+    }
+
+    getEntry(view) {
+        return this._entry.get(view);
+    }
+
+    setEntries(view, entries) {
+        this._entries.set(view, entries);
+
+        return this;
+    }
+
+    getEntries(view) {
+        return this._entries.get(view);
+    }
+
+    setReferences(view, references) {
+        this._references.set(view, references);
+
+        return this;
+    }
+
+    getReferences(view) {
+        return this._references.get(view);
+    }
+}
+
+export default DataStore;

--- a/src/javascripts/ng-admin/es6/lib/DataStore/DataStore.js
+++ b/src/javascripts/ng-admin/es6/lib/DataStore/DataStore.js
@@ -24,7 +24,9 @@ class DataStore {
     }
 
     getFirstEntry(name) {
-        return this._entries[name][0];
+        var entries = this.getEntries(name);
+
+        return entries.length ? entries[0] : null;
     }
 
     getChoices(field) {

--- a/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
+++ b/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
@@ -1,5 +1,6 @@
 import stringUtils from "../Utils/stringUtils";
 import Field from "../Field/Field";
+import DataStore from '../DataStore/DataStore';
 import DashboardView from '../View/DashboardView';
 import MenuView from '../View/MenuView';
 import ListView from '../View/ListView';
@@ -13,6 +14,7 @@ import ExportView from '../View/ExportView';
 class Entity {
     constructor(name) {
         this._name = name;
+        this._dataStore = new DataStore(name);
         this._baseApiUrl = null;
         this._label = null;
         this._identifierField = new Field("id");
@@ -22,6 +24,11 @@ class Entity {
         this._url = null;
 
         this._initViews();
+
+    }
+
+    get dataStore() {
+        return this._dataStore;
     }
 
     get views() {
@@ -121,15 +128,15 @@ class Entity {
 
     _initViews() {
         this._views = {
-            "DashboardView": new DashboardView().setEntity(this),
-            "MenuView": new MenuView().setEntity(this),
-            "ListView": new ListView().setEntity(this),
-            "CreateView": new CreateView().setEntity(this),
-            "EditView": new EditView().setEntity(this),
-            "DeleteView": new DeleteView().setEntity(this),
-            "BatchDeleteView": new BatchDeleteView().setEntity(this),
-            "ExportView": new ExportView().setEntity(this),
-            "ShowView": new ShowView().setEntity(this)
+            "DashboardView": new DashboardView().setEntity(this).setDataStore(this._dataStore),
+            "MenuView": new MenuView().setEntity(this).setDataStore(this._dataStore),
+            "ListView": new ListView().setEntity(this).setDataStore(this._dataStore),
+            "CreateView": new CreateView().setEntity(this).setDataStore(this._dataStore),
+            "EditView": new EditView().setEntity(this).setDataStore(this._dataStore),
+            "DeleteView": new DeleteView().setEntity(this).setDataStore(this._dataStore),
+            "BatchDeleteView": new BatchDeleteView().setEntity(this).setDataStore(this._dataStore),
+            "ExportView": new ExportView().setEntity(this).setDataStore(this._dataStore),
+            "ShowView": new ShowView().setEntity(this).setDataStore(this._dataStore)
         };
     }
 
@@ -186,7 +193,7 @@ class Entity {
         }
 
         return this._url;
-    };
+    }
 }
 
 export default Entity;

--- a/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
+++ b/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
@@ -10,9 +10,12 @@ import ShowView from '../View/ShowView';
 import BatchDeleteView from '../View/BatchDeleteView';
 import ExportView from '../View/ExportView';
 
+var index = 0;
+
 class Entity {
     constructor(name) {
         this._name = name;
+        this._uniqueId = this._name + '_' + index++;
         this._baseApiUrl = null;
         this._label = null;
         this._identifierField = new Field("id");
@@ -22,6 +25,10 @@ class Entity {
         this._url = null;
 
         this._initViews();
+    }
+
+    get uniqueId() {
+        return this._uniqueId;
     }
 
     get views() {

--- a/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
+++ b/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
@@ -1,6 +1,5 @@
 import stringUtils from "../Utils/stringUtils";
 import Field from "../Field/Field";
-import DataStore from '../DataStore/DataStore';
 import DashboardView from '../View/DashboardView';
 import MenuView from '../View/MenuView';
 import ListView from '../View/ListView';
@@ -14,7 +13,6 @@ import ExportView from '../View/ExportView';
 class Entity {
     constructor(name) {
         this._name = name;
-        this._dataStore = new DataStore(name);
         this._baseApiUrl = null;
         this._label = null;
         this._identifierField = new Field("id");
@@ -24,11 +22,6 @@ class Entity {
         this._url = null;
 
         this._initViews();
-
-    }
-
-    get dataStore() {
-        return this._dataStore;
     }
 
     get views() {
@@ -128,15 +121,15 @@ class Entity {
 
     _initViews() {
         this._views = {
-            "DashboardView": new DashboardView().setEntity(this).setDataStore(this._dataStore),
-            "MenuView": new MenuView().setEntity(this).setDataStore(this._dataStore),
-            "ListView": new ListView().setEntity(this).setDataStore(this._dataStore),
-            "CreateView": new CreateView().setEntity(this).setDataStore(this._dataStore),
-            "EditView": new EditView().setEntity(this).setDataStore(this._dataStore),
-            "DeleteView": new DeleteView().setEntity(this).setDataStore(this._dataStore),
-            "BatchDeleteView": new BatchDeleteView().setEntity(this).setDataStore(this._dataStore),
-            "ExportView": new ExportView().setEntity(this).setDataStore(this._dataStore),
-            "ShowView": new ShowView().setEntity(this).setDataStore(this._dataStore)
+            "DashboardView": new DashboardView().setEntity(this),
+            "MenuView": new MenuView().setEntity(this),
+            "ListView": new ListView().setEntity(this),
+            "CreateView": new CreateView().setEntity(this),
+            "EditView": new EditView().setEntity(this),
+            "DeleteView": new DeleteView().setEntity(this),
+            "BatchDeleteView": new BatchDeleteView().setEntity(this),
+            "ExportView": new ExportView().setEntity(this),
+            "ShowView": new ShowView().setEntity(this)
         };
     }
 
@@ -193,7 +186,7 @@ class Entity {
         }
 
         return this._url;
-    }
+    };
 }
 
 export default Entity;

--- a/src/javascripts/ng-admin/es6/lib/Entry.js
+++ b/src/javascripts/ng-admin/es6/lib/Entry.js
@@ -14,15 +14,14 @@ class Entry {
         return this._identifierValue;
     }
 
-    static mapFromRest(view, restEntry) {
+    static mapFromRest(entityName, identifier, fields, restEntry) {
         if (!restEntry) {
-            return new Entry(view.entity.name());
+            return new Entry(entityName);
         }
 
-        var identifier = view.identifier();
         var identifierValue = null;
 
-        view.fields().forEach(function (field) {
+        fields.forEach(function (field) {
             var fieldName = field.name();
             if (fieldName in restEntry) {
                 restEntry[fieldName] = field.getMappedValue(restEntry[fieldName], restEntry);
@@ -34,7 +33,7 @@ class Entry {
             identifierValue = restEntry[identifier.name()];
         }
 
-        return new Entry(view.entity.name(), restEntry, identifierValue);
+        return new Entry(entityName, restEntry, identifierValue);
     }
 }
 

--- a/src/javascripts/ng-admin/es6/lib/Factory.js
+++ b/src/javascripts/ng-admin/es6/lib/Factory.js
@@ -1,5 +1,6 @@
 import Application from "./Application";
 import Entity from "./Entity/Entity";
+import DataStore from "./DataStore/DataStore";
 
 import Field from "./Field/Field";
 import BooleanField from "./Field/BooleanField";
@@ -24,6 +25,7 @@ import Menu from './Menu/Menu';
 class Factory {
     constructor() {
         this._fieldTypes = [];
+        this._dataStore = new DataStore();
         this._init();
     }
 
@@ -36,7 +38,8 @@ class Factory {
     }
 
     field(name, type) {
-        var type = type || "string";
+        type = type || 'string';
+
         if (!(type in this._fieldTypes)) {
             throw new Error(`Unknown field type "${type}".`);
         }
@@ -58,6 +61,10 @@ class Factory {
             menu.populateFromEntity(entity);
         }
         return menu;
+    }
+
+    getDataStore() {
+        return this._dataStore;
     }
 
     _init() {

--- a/src/javascripts/ng-admin/es6/lib/Factory.js
+++ b/src/javascripts/ng-admin/es6/lib/Factory.js
@@ -25,7 +25,6 @@ import Menu from './Menu/Menu';
 class Factory {
     constructor() {
         this._fieldTypes = [];
-        this._dataStore = new DataStore();
         this._init();
     }
 
@@ -64,7 +63,7 @@ class Factory {
     }
 
     getDataStore() {
-        return this._dataStore;
+        return new DataStore();
     }
 
     _init() {

--- a/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
+++ b/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
@@ -1,7 +1,7 @@
-import ChoiceField from "./ChoiceField";
+import Field from "./Field";
 import ListView from "../View/ListView";
 
-class ReferenceField extends ChoiceField {
+class ReferenceField extends Field {
     constructor(name) {
         super(name);
         this._type = 'reference';

--- a/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
+++ b/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
@@ -4,7 +4,6 @@ import ListView from "../View/ListView";
 class ReferenceField extends ChoiceField {
     constructor(name) {
         super(name);
-        this.entries = [];
         this._type = 'reference';
         this._targetEntity = null;
         this._targetField = null;
@@ -29,7 +28,7 @@ class ReferenceField extends ChoiceField {
         }
 
         this._targetEntity = entity;
-        this._referencedView = new ListView().setEntity(entity);
+        this._referencedView = new ListView().setEntity(entity).setDataStore(this._targetEntity.dataStore);
         if (this._targetField) {
             this._referencedView.addField(this._targetField);
         }
@@ -122,9 +121,10 @@ class ReferenceField extends ChoiceField {
         var targetEntity = this._targetEntity;
         var targetField = this._targetField.name();
         var targetIdentifier = targetEntity.identifier().name();
+        var entries = this._referencedView.getReferencesEntries();
 
-        for (var i = 0, l = this.entries.length ; i < l ; i++) {
-            var entry = this.entries[i];
+        for (var i = 0, l = entries.length ; i < l ; i++) {
+            var entry = entries[i];
             result[entry.values[targetIdentifier]] = entry.values[targetField];
         }
 
@@ -132,7 +132,7 @@ class ReferenceField extends ChoiceField {
     }
 
     choices() {
-        return this.entries.map(function(entry) {
+        return this._referencedView.getReferencesEntries().map(function(entry) {
             return {
                 value: entry.values[this._targetEntity.identifier().name()],
                 label: entry.values[this._targetField.name()]

--- a/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
+++ b/src/javascripts/ng-admin/es6/lib/Field/ReferenceField.js
@@ -28,7 +28,7 @@ class ReferenceField extends ChoiceField {
         }
 
         this._targetEntity = entity;
-        this._referencedView = new ListView().setEntity(entity).setDataStore(this._targetEntity.dataStore);
+        this._referencedView = new ListView().setEntity(entity);
         if (this._targetField) {
             this._referencedView.addField(this._targetField);
         }
@@ -88,11 +88,11 @@ class ReferenceField extends ChoiceField {
 
     hasSingleApiCall() {
         return typeof this._singleApiCall === 'function';
-    };
+    }
 
     getSingleApiCall(identifiers) {
         return this.hasSingleApiCall() ? this._singleApiCall(identifiers) : this._singleApiCall;
-    };
+    }
 
     getIdentifierValues(rawValues) {
         var results = {};
@@ -114,30 +114,6 @@ class ReferenceField extends ChoiceField {
         }
 
         return Object.keys(results);
-    }
-
-    getChoicesById() {
-        var result = {};
-        var targetEntity = this._targetEntity;
-        var targetField = this._targetField.name();
-        var targetIdentifier = targetEntity.identifier().name();
-        var entries = this._referencedView.getReferencesEntries();
-
-        for (var i = 0, l = entries.length ; i < l ; i++) {
-            var entry = entries[i];
-            result[entry.values[targetIdentifier]] = entry.values[targetField];
-        }
-
-        return result;
-    }
-
-    choices() {
-        return this._referencedView.getReferencesEntries().map(function(entry) {
-            return {
-                value: entry.values[this._targetEntity.identifier().name()],
-                label: entry.values[this._targetField.name()]
-            };
-        }, this);
     }
 
     getSortFieldName() {

--- a/src/javascripts/ng-admin/es6/lib/View/ListView.js
+++ b/src/javascripts/ng-admin/es6/lib/View/ListView.js
@@ -96,7 +96,14 @@ class ListView extends View {
     }
 
     getFilterReferences() {
-        return this._filters.filter(f => f.type() === 'reference');
+        var result = {};
+        var lists = this._fields.filter(f => f.type() === 'reference');
+        for (let i = 0, c = lists.length ; i < c ; i++) {
+            let list = lists[i];
+            result[list.name()] = list;
+        }
+
+        return result;
     }
 
     listActions(actions) {

--- a/src/javascripts/ng-admin/es6/lib/View/View.js
+++ b/src/javascripts/ng-admin/es6/lib/View/View.js
@@ -3,6 +3,7 @@ import Entry from "../Entry";
 class View {
     constructor(name) {
         this.entity = null;
+        this._dataStore = null;
         this._actions = null;
         this._title = false;
         this._description = '';
@@ -79,6 +80,11 @@ class View {
         return this;
     }
 
+    setDataStore(dataStore) {
+        this._dataStore = dataStore;
+
+        return this;
+    }
 
     /*
      * Supports various syntax
@@ -139,14 +145,38 @@ class View {
         }
 
         return result;
-    };
+    }
 
     mapEntry(restEntry) {
-        return new Entry.mapFromRest(this, restEntry);
+        var entry = new Entry.mapFromRest(this, restEntry);
+
+        return entry;
+    }
+
+    setEntry(entry) {
+        this._dataStore.setEntry(this, entry);
+
+        return this;
     }
 
     mapEntries(restEntries) {
         return restEntries.map(e => this.mapEntry(e));
+    }
+
+    setEntries(entries) {
+        this._dataStore.setEntries(this, entries);
+
+        return this;
+    }
+
+    setReferences(references) {
+        this._dataStore.setReferences(this, references);
+
+        return this;
+    }
+
+    getReferencesEntries() {
+        return this._dataStore.getReferences(this);
     }
 
     template(template) {
@@ -251,7 +281,7 @@ class View {
         }
 
         return this._url;
-    };
+    }
 }
 
 export default View;

--- a/src/javascripts/ng-admin/es6/lib/View/View.js
+++ b/src/javascripts/ng-admin/es6/lib/View/View.js
@@ -3,7 +3,6 @@ import Entry from "../Entry";
 class View {
     constructor(name) {
         this.entity = null;
-        this._dataStore = null;
         this._actions = null;
         this._title = false;
         this._description = '';
@@ -80,12 +79,6 @@ class View {
         return this;
     }
 
-    setDataStore(dataStore) {
-        this._dataStore = dataStore;
-
-        return this;
-    }
-
     /*
      * Supports various syntax
      * fields([ Field1, Field2 ])
@@ -147,38 +140,6 @@ class View {
         return result;
     }
 
-    mapEntry(restEntry) {
-        var entry = new Entry.mapFromRest(this, restEntry);
-
-        return entry;
-    }
-
-    setEntry(entry) {
-        this._dataStore.setEntry(this, entry);
-
-        return this;
-    }
-
-    mapEntries(restEntries) {
-        return restEntries.map(e => this.mapEntry(e));
-    }
-
-    setEntries(entries) {
-        this._dataStore.setEntries(this, entries);
-
-        return this;
-    }
-
-    setReferences(references) {
-        this._dataStore.setReferences(this, references);
-
-        return this;
-    }
-
-    getReferencesEntries() {
-        return this._dataStore.getReferences(this);
-    }
-
     template(template) {
         if (!arguments.length) {
             return this._template;
@@ -218,22 +179,12 @@ class View {
         return this;
     }
 
-    processFieldsDefaultValue(entry) {
-
-        this._fields.forEach(function (field) {
-            entry.values[field.name()] = field.defaultValue();
-        });
-
-        return entry;
-    }
-
     removeFields() {
         this._fields = [];
         return this;
     }
 
     getFields() {
-
         return this._fields;
     }
 

--- a/src/javascripts/ng-admin/es6/lib/View/View.js
+++ b/src/javascripts/ng-admin/es6/lib/View/View.js
@@ -126,7 +126,14 @@ class View {
     }
 
     getReferences() {
-        return this._fields.filter(field => field.type() === 'reference' || field.type() === 'reference_many');
+        var result = {};
+        var lists = this._fields.filter(f => f.type() === 'reference' || f.type() === 'reference_many');
+        for (let i = 0, c = lists.length ; i < c ; i++) {
+            let list = lists[i];
+            result[list.name()] = list;
+        }
+
+        return result;
     }
 
     getReferencedLists() {

--- a/src/javascripts/ng-admin/es6/tests/lib/DataStore/DataStore.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/DataStore/DataStore.js
@@ -34,7 +34,7 @@ describe('DataStore', function() {
         assert.equal(entries[1].values.published, false);
     });
 
-    it('should map some one entity when the identifier in not in the view', function () {
+    it('should map some one entity when the identifier is not in the view', function () {
         var view = new View(),
             field = new Field('title'),
             entity = new Entity('posts');

--- a/src/javascripts/ng-admin/es6/tests/lib/DataStore/DataStore.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/DataStore/DataStore.js
@@ -1,0 +1,111 @@
+var assert = require('chai').assert;
+
+import DataStore from "../../../lib/DataStore/DataStore";
+import Entity from "../../../lib/Entity/Entity";
+import Entry from "../../../lib/Entry";
+import Field from "../../../lib/Field/Field";
+import ReferenceField from "../../../lib/Field/ReferenceField";
+import View from "../../../lib/View/View";
+
+describe('DataStore', function() {
+    var dataStore;
+
+    beforeEach(function() {
+        dataStore = new DataStore();
+    });
+
+    it('should map some raw entities', function () {
+        var view = new View();
+        view
+            .addField(new Field('post_id').identifier(true))
+            .addField(new Field('title'))
+            .setEntity(new Entity());
+
+        var entries = dataStore.mapEntries(view, [
+            { post_id: 1, title: 'Hello', published: true},
+            { post_id: 2, title: 'World', published: false},
+            { post_id: 3, title: 'How to use ng-admin', published: false}
+        ]);
+
+        assert.equal(entries.length, 3);
+        assert.equal(entries[0].identifierValue, 1);
+        assert.equal(entries[1].values.title, 'World');
+        assert.equal(entries[1].values.published, false);
+    });
+
+    it('should map some one entity when the identifier in not in the view', function () {
+        var view = new View(),
+            field = new Field('title'),
+            entity = new Entity('posts');
+
+        view
+            .addField(field)
+            .setEntity(entity);
+
+        entity
+            .identifier(new Field('post_id'));
+
+        var entry = dataStore.mapEntry(view, { post_id: 1, title: 'Hello', published: true});
+        assert.equal(entry.identifierValue, 1);
+        assert.equal(entry.values.title, 'Hello');
+    });
+
+    describe('getChoicesById', function () {
+        it('should retrieve choices by id.', function () {
+            var ref = new ReferenceField('human_id'),
+                human = new Entity('human');
+
+            human
+                .identifier(new Field('id'))
+                .editionView()
+                .addField(new Field('id').identifier(true));
+
+            ref
+                .targetEntity(human)
+                .targetField(new Field('name'));
+
+            dataStore.setEntries(ref.getReferencedView(), [
+                {values: { id: 1, human_id: 1, name: 'Suna'}},
+                {values: { id: 2, human_id: 2, name: 'Boby'}},
+                {values: { id: 3, human_id: 1, name: 'Mizute'}}
+            ]);
+
+            var choices = dataStore.getReferenceChoicesById(ref);
+            assert.equal(ref.type(), 'reference');
+            assert.deepEqual(choices, {
+                1: 'Suna',
+                2: 'Boby',
+                3: 'Mizute'
+            });
+        });
+    });
+
+    describe('choices', function () {
+        it('should retrieve choices.', function () {
+            var ref = new ReferenceField('human_id'),
+                human = new Entity('human');
+
+            human
+                .identifier(new Field('id'))
+                .editionView()
+                .addField(new Field('id').identifier(true));
+
+            ref
+                .targetField(new Field('name'))
+                .targetEntity(human);
+
+            dataStore.setEntries(ref.getReferencedView(), [
+                new Entry('human', { id: 1, human_id: 1, name: 'Suna'}),
+                new Entry('human', { id: 2, human_id: 2, name: 'Boby'}),
+                new Entry('human', { id: 3, human_id: 1, name: 'Mizute'})
+            ]);
+
+            assert.equal(ref.type(), 'reference');
+            assert.deepEqual(dataStore.getChoices(ref), [
+                { value: 1, label: 'Suna'},
+                { value: 2, label: 'Boby'},
+                { value: 3, label: 'Mizute'}
+            ]);
+        });
+    });
+});

--- a/src/javascripts/ng-admin/es6/tests/lib/EntryTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/EntryTest.js
@@ -19,12 +19,14 @@ describe('Entry', function() {
         });
 
         it('should return entry with no value if REST entry is empty', function() {
-            var mappedEntry = Entry.mapFromRest(entity.listView(), {});
+            var view = entity.listView();
+            var mappedEntry = Entry.mapFromRest(entity.name(), view.identifier(), view.getFields(), {});
             assert.deepEqual({}, mappedEntry.values);
         });
 
         it('should map each value to related field if existing', function() {
-            var mappedEntry = Entry.mapFromRest(entity.listView(), {
+            var view = entity.listView();
+            var mappedEntry = Entry.mapFromRest(entity.name(), view.identifier(), view.getFields(), {
                 id: 1,
                 title: 'ng-admin + ES6 = pure awesomeness!',
                 body: 'Really, it rocks!',
@@ -40,7 +42,8 @@ describe('Entry', function() {
         });
 
         it('should set as identifierValue value for identifier field', function() {
-            var mappedEntry = Entry.mapFromRest(entity.listView(), { id: 1 });
+            var view = entity.listView();
+            var mappedEntry = Entry.mapFromRest(entity.name(), view.identifier(), view.getFields(), { id: 1 });
             assert.equal(1, mappedEntry.identifierValue);
         });
     });

--- a/src/javascripts/ng-admin/es6/tests/lib/Field/ReferenceFieldTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/Field/ReferenceFieldTest.js
@@ -13,65 +13,6 @@ describe('ReferenceField', function() {
         });
     });
 
-    describe('getChoicesById', function () {
-        it('should retrieve choices by id.', function () {
-            var ref = new ReferenceField('human_id'),
-                human = new Entity('human');
-
-            human
-                .identifier(new Field('id'))
-                .editionView()
-                .addField(new Field('id').identifier(true));
-
-            ref
-                .targetEntity(human)
-                .targetField(new Field('name'));
-
-            ref.entries = [
-                {values: { id: 1, human_id: 1, name: 'Suna'}},
-                {values: { id: 2, human_id: 2, name: 'Boby'}},
-                {values: { id: 3, human_id: 1, name: 'Mizute'}}
-            ];
-
-            var choices = ref.getChoicesById();
-            assert.equal(ref.type(), 'reference');
-            assert.deepEqual(choices, {
-                1: 'Suna',
-                2: 'Boby',
-                3: 'Mizute'
-            });
-        });
-    });
-
-    describe('choices', function () {
-        it('should retrieve choices.', function () {
-            var ref = new ReferenceField('human_id'),
-                human = new Entity('human');
-
-            human
-                .identifier(new Field('id'))
-                .editionView()
-                .addField(new Field('id').identifier(true));
-
-            ref
-                .targetField(new Field('name'))
-                .targetEntity(human);
-
-            ref.entries = [
-                new Entry('human', { id: 1, human_id: 1, name: 'Suna'}),
-                new Entry('human', { id: 2, human_id: 2, name: 'Boby'}),
-                new Entry('human', { id: 3, human_id: 1, name: 'Mizute'})
-            ];
-
-            assert.equal(ref.type(), 'reference');
-            assert.deepEqual(ref.choices(), [
-                { value: 1, label: 'Suna'},
-                { value: 2, label: 'Boby'},
-                { value: 3, label: 'Mizute'}
-            ]);
-        });
-    });
-
     it('Should create a fake view to keep entity', function () {
         var post = new Entity('posts'),
             comment = new Entity('comments');

--- a/src/javascripts/ng-admin/es6/tests/lib/View/ViewTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/View/ViewTest.js
@@ -170,40 +170,4 @@ describe('View', function() {
 
         assert.equal(view.identifier().name(), 'post_id');
     });
-
-    it('should map some raw entities', function () {
-        var view = new View();
-        view
-            .addField(new Field('post_id').identifier(true))
-            .addField(new Field('title'))
-            .setEntity(new Entity());
-
-        var entries = view.mapEntries([
-            { post_id: 1, title: 'Hello', published: true},
-            { post_id: 2, title: 'World', published: false},
-            { post_id: 3, title: 'How to use ng-admin', published: false}
-        ]);
-
-        assert.equal(entries.length, 3);
-        assert.equal(entries[0].identifierValue, 1);
-        assert.equal(entries[1].values.title, 'World');
-        assert.equal(entries[1].values.published, false);
-    });
-
-    it('should map some one entity when the identifier in not in the view', function () {
-        var view = new View(),
-            field = new Field('title'),
-            entity = new Entity('posts');
-
-        view
-            .addField(field)
-            .setEntity(entity);
-
-        entity
-            .identifier(new Field('post_id'));
-
-        var entry = view.mapEntry({ post_id: 1, title: 'Hello', published: true});
-        assert.equal(entry.identifierValue, 1);
-        assert.equal(entry.values.title, 'Hello');
-    });
 });

--- a/src/javascripts/ng-admin/es6/tests/lib/View/ViewTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/View/ViewTest.js
@@ -39,7 +39,7 @@ describe('View', function() {
         });
     });
 
-    describe('getReferenceFields()', function() {
+    describe('getReferences()', function() {
         it('should return only reference and reference_many fields', function() {
             var post = new Entity('post');
             var category = new ReferenceField('category');
@@ -50,7 +50,7 @@ describe('View', function() {
                 tags
             ]);
 
-            assert.deepEqual([category, tags], view.getReferences());
+            assert.deepEqual({category: category, tags: tags}, view.getReferences());
         });
     });
 
@@ -65,8 +65,8 @@ describe('View', function() {
             view.addField(ref).addField(refMany).addField(field);
 
             assert.equal(view.getFieldsOfType('reference_many')[0].name(), 'refMany');
-            assert.equal(view.getReferences()[0].name(), 'myRef');
-            assert.equal(view.getReferences()[1].name(), 'refMany');
+            assert.equal(view.getReferences()['myRef'].name(), 'myRef');
+            assert.equal(view.getReferences()['refMany'].name(), 'refMany');
             assert.equal(view.getFields()[2].name(), 'body');
         });
     });

--- a/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
@@ -6,7 +6,12 @@ define(function (require) {
     describe('directive: choice-field', function () {
         var directive = require('ng-admin/Crud/field/maChoiceField');
         var ChoiceField = require('ng-admin/es6/lib/Field/ChoiceField');
-        angular.module('testapp_ChoiceField', []).directive('maChoiceField', directive);
+        var DataStore = require('ng-admin/es6/lib/DataStore/DataStore');
+
+        var dataStoreModule = angular.module('testapp_DataStore', []);
+        dataStoreModule.constant('DataStore', new DataStore());
+
+        angular.module('testapp_ChoiceField', ['testapp_DataStore']).directive('maChoiceField', directive);
         require('angular-mocks');
 
         var $compile,

--- a/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoiceFieldSpec.js
@@ -6,12 +6,8 @@ define(function (require) {
     describe('directive: choice-field', function () {
         var directive = require('ng-admin/Crud/field/maChoiceField');
         var ChoiceField = require('ng-admin/es6/lib/Field/ChoiceField');
-        var DataStore = require('ng-admin/es6/lib/DataStore/DataStore');
 
-        var dataStoreModule = angular.module('testapp_DataStore', []);
-        dataStoreModule.constant('DataStore', new DataStore());
-
-        angular.module('testapp_ChoiceField', ['testapp_DataStore']).directive('maChoiceField', directive);
+        angular.module('testapp_ChoiceField', []).directive('maChoiceField', directive);
         require('angular-mocks');
 
         var $compile,

--- a/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maChoicesFieldSpec.js
@@ -6,7 +6,12 @@ define(function (require) {
     describe('directive: choices-field', function() {
         var directive = require('ng-admin/Crud/field/maChoicesField');
         var ChoiceField = require('ng-admin/es6/lib/Field/ChoiceField');
-        angular.module('testapp_ChoicesField', []).directive('maChoicesField', directive);
+        var DataStore = require('ng-admin/es6/lib/DataStore/DataStore');
+
+        var dataStoreModule = angular.module('testapp_DataStore', []);
+        dataStoreModule.constant('DataStore', new DataStore());
+
+        angular.module('testapp_ChoicesField', ['testapp_DataStore']).directive('maChoicesField', directive);
         require('angular-mocks');
 
         var $compile,

--- a/src/javascripts/test/unit/Crud/repository/CreateQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/CreateQueriesSpec.js
@@ -7,11 +7,14 @@ define(function (require) {
         Field = require('ng-admin/es6/lib/Field/Field'),
         TextField = require('ng-admin/es6/lib/Field/TextField'),
         Entity = require('ng-admin/es6/lib/Entity/Entity'),
+        DataStore = require('ng-admin/es6/lib/DataStore/DataStore'),
         Restangular = require('mock/Restangular'),
         mixins = require('mixins'),
         config,
         entity,
         view;
+
+    var dataStore = new DataStore();
 
     describe("Service: CreateQueries", function () {
 
@@ -37,7 +40,7 @@ define(function (require) {
         describe("createOne", function () {
 
             it('should POST an entity when calling createOne', function (done) {
-                var createQueries = new CreateQueries({}, Restangular, config),
+                var createQueries = new CreateQueries({}, Restangular, config, dataStore),
                     rawEntity = {name: 'Mizu'};
 
                 spyOn(Restangular, 'customPOST').and.returnValue(mixins.buildPromise({data: rawEntity}));

--- a/src/javascripts/test/unit/Crud/repository/CreateQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/CreateQueriesSpec.js
@@ -14,8 +14,6 @@ define(function (require) {
         entity,
         view;
 
-    var dataStore = new DataStore();
-
     describe("Service: CreateQueries", function () {
 
         beforeEach(function () {
@@ -40,16 +38,19 @@ define(function (require) {
         describe("createOne", function () {
 
             it('should POST an entity when calling createOne', function (done) {
-                var createQueries = new CreateQueries({}, Restangular, config, dataStore),
+                var createQueries = new CreateQueries({}, Restangular, config),
                     rawEntity = {name: 'Mizu'};
 
                 spyOn(Restangular, 'customPOST').and.returnValue(mixins.buildPromise({data: rawEntity}));
                 spyOn(Restangular, 'oneUrl').and.callThrough();
 
                 createQueries.createOne(view, rawEntity)
-                    .then(function (entry) {
+                    .then(function (rawEntry) {
                         expect(Restangular.oneUrl).toHaveBeenCalledWith('cat', 'http://localhost/cat');
                         expect(Restangular.customPOST).toHaveBeenCalledWith(rawEntity);
+
+                        var dataStore = new DataStore();
+                        var entry = dataStore.mapEntry(entity.name(), view.identifier(), view.getFields(), rawEntry);
                         expect(entry.values.name).toEqual('Mizu');
                     })
                     .then(done, done.fail);

--- a/src/javascripts/test/unit/Crud/repository/RetrieveQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/RetrieveQueriesSpec.js
@@ -7,27 +7,20 @@ define(function (require) {
         Field = require('ng-admin/es6/lib/Field/Field'),
         TextField = require('ng-admin/es6/lib/Field/TextField'),
         Entity = require('ng-admin/es6/lib/Entity/Entity'),
-        Entry = require('ng-admin/es6/lib/Entry'),
         ReferenceField = require('ng-admin/es6/lib/Field/ReferenceField'),
         ReferencedListField = require('ng-admin/es6/lib/Field/ReferencedListField'),
-        ReferenceManyField = require('ng-admin/es6/lib/Field/ReferenceManyField'),
-        DataStore = require('ng-admin/es6/lib/DataStore/DataStore'),
         Restangular = require('mock/Restangular'),
         mixins = require('mixins'),
         PromisesResolver = require('mock/PromisesResolver'),
         $q = require('mock/q'),
         config,
-        cats,
         rawCats,
-        humans,
         rawHumans,
         catEntity,
         humanEntity,
         catView,
         entity,
         view;
-
-    var dataStore = new DataStore();
 
     describe("Service: RetrieveQueries", function () {
 
@@ -55,51 +48,37 @@ define(function (require) {
                 {"id": 2, "human_id": 1, "name": "Suna", "summary": "A little Cat"}
             ];
 
-            cats = [
-                new Entry('cat', rawCats[0]),
-                new Entry('cat', rawCats[1])
-            ];
-
             rawHumans = [
                 {"id": 1, "firstName": "Daph"},
                 {"id": 2, "firstName": "Manu"},
                 {"id": 3, "firstName": "Daniel"}
-            ];
-
-            humans = [
-                new Entry('human', rawHumans[0]),
-                new Entry('human', rawHumans[1]),
-                new Entry('human', rawHumans[2])
             ];
         });
 
         describe('getAll', function() {
             it('should return all data to display a ListView', function (done) {
                 spyOn(Restangular, 'getList').and.returnValue(mixins.buildPromise({data: rawCats, headers: function() {}}));
-                spyOn(PromisesResolver, 'allEvenFailed').and.returnValue(mixins.buildPromise([{status: 'success', result: humans[0] }, {status: 'success', result: humans[1] }, {status: 'success', result: humans[2] }]));
+                spyOn(PromisesResolver, 'allEvenFailed').and.returnValue(mixins.buildPromise([{status: 'success', result: rawHumans[0] }, {status: 'success', result: rawHumans[1] }, {status: 'success', result: rawHumans[2] }]));
 
-                var retrieveQueries = new RetrieveQueries($q, Restangular, config, dataStore, PromisesResolver);
+                var retrieveQueries = new RetrieveQueries($q, Restangular, config, PromisesResolver);
 
                 retrieveQueries.getAll(catView)
                     .then(function (result) {
-                        expect(result.currentPage).toEqual(1);
-                        expect(result.perPage).toEqual(30);
                         expect(result.totalItems).toEqual(2);
-                        expect(result.entries.length).toEqual(2);
+                        expect(result.data.length).toEqual(2);
 
-                        expect(result.entries[0].values.id).toEqual(1);
-                        expect(result.entries[0].values.name).toEqual('Mizoute');
+                        expect(result.data[0].id).toEqual(1);
+                        expect(result.data[0].name).toEqual('Mizoute');
 
-                        expect(result.entries[0].values.human_id).toEqual(1);
-                        expect(result.entries[0].listValues.human_id).toEqual('Daph');
+                        expect(result.data[0].human_id).toEqual(1);
                     })
                     .then(done, done.fail);
             });
         });
 
-        describe('getReferencedValues', function() {
-            it('should return all references values for a View with multiple calls', function (done) {
-                var retrieveQueries = new RetrieveQueries($q, Restangular, config, dataStore, PromisesResolver),
+        describe('getReferencedData', function() {
+            it('should return all references data for a View with multiple calls', function (done) {
+                var retrieveQueries = new RetrieveQueries($q, Restangular, config, PromisesResolver),
                     post = new Entity('posts'),
                     author = new Entity('authors'),
                     authorRef = new ReferenceField('author');
@@ -109,9 +88,9 @@ define(function (require) {
                     {id: 2, author: '19DFE'}
                 ];
 
-                var authors = [
-                    new Entry('author', {id: 'abc', name: 'Rollo'}),
-                    new Entry('author', {id: '19DFE', name: 'Ragna'})
+                var rawAuthors = [
+                    {id: 'abc', name: 'Rollo'},
+                    {id: '19DFE', name: 'Ragna'}
                 ];
 
                 authorRef.targetEntity(author);
@@ -120,21 +99,19 @@ define(function (require) {
                     .addField(authorRef);
 
                 spyOn(Restangular, 'get').and.returnValue(mixins.buildPromise(mixins.buildPromise({})));
-                spyOn(PromisesResolver, 'allEvenFailed').and.returnValue(mixins.buildPromise([{status: 'success', result: authors[0] }, { status: 'success', result: authors[1] }]));
+                spyOn(PromisesResolver, 'allEvenFailed').and.returnValue(mixins.buildPromise([{status: 'success', result: rawAuthors[0] }, { status: 'success', result: rawAuthors[1] }]));
 
-                retrieveQueries.getReferencedValues(post.listView().getReferences(), rawPosts)
-                    .then(function (references) {
-                        var entries = dataStore.getEntries(authorRef.getReferencedView());
-
-                        expect(entries.length).toEqual(2);
-                        expect(entries[0].values.id).toEqual('abc');
-                        expect(entries[1].values.name).toEqual('Ragna');
+                retrieveQueries.getReferencedData(post.listView().getReferences(), rawPosts)
+                    .then(function (referencedData) {
+                        expect(referencedData.author.length).toEqual(2);
+                        expect(referencedData.author[0].id).toEqual('abc');
+                        expect(referencedData.author[1].name).toEqual('Ragna');
                     })
                     .then(done, done.fail);
             });
 
-            it('should return all references values for a View with one call', function (done) {
-                var retrieveQueries = new RetrieveQueries($q, Restangular, config, dataStore, PromisesResolver),
+            it('should return all references data for a View with one call', function (done) {
+                var retrieveQueries = new RetrieveQueries($q, Restangular, config, PromisesResolver),
                     post = new Entity('posts'),
                     author = new Entity('authors'),
                     authorRef = new ReferenceField('author');
@@ -155,11 +132,6 @@ define(function (require) {
                     {id: '19DFE', name: 'Ragna'}
                 ];
 
-                var authors = [
-                    new Entry('authors', rawAuthors[0]),
-                    new Entry('authors', rawAuthors[1])
-                ];
-
                 authorRef.targetEntity(author);
                 authorRef.targetField(new Field('name'));
                 post.listView()
@@ -168,21 +140,19 @@ define(function (require) {
                 spyOn(Restangular, 'getList').and.returnValue(mixins.buildPromise(mixins.buildPromise({})));
                 spyOn(PromisesResolver, 'allEvenFailed').and.returnValue(mixins.buildPromise([{status: 'success', result: { data: rawAuthors }}]));
 
-                retrieveQueries.getReferencedValues(post.listView().getReferences(), rawPosts)
-                    .then(function (references) {
-                        var entries = dataStore.getEntries(authorRef.getReferencedView());
-
-                        expect(entries.length).toEqual(2);
-                        expect(entries[0].values.id).toEqual('abc');
-                        expect(entries[1].values.name).toEqual('Ragna');
+                retrieveQueries.getReferencedData(post.listView().getReferences(), rawPosts)
+                    .then(function (referencedData) {
+                        expect(referencedData['author'].length).toEqual(2);
+                        expect(referencedData['author'][0].id).toEqual('abc');
+                        expect(referencedData['author'][1].name).toEqual('Ragna');
                     })
                     .then(done, done.fail);
             });
         });
 
-        describe('getReferencedListValues', function() {
-            it('should return all referencedLists values for a View', function (done) {
-                var retrieveQueries = new RetrieveQueries($q, Restangular, config, dataStore, PromisesResolver),
+        describe('getReferencedListData', function() {
+            it('should return all referencedLists data for a View', function (done) {
+                var retrieveQueries = new RetrieveQueries($q, Restangular, config, PromisesResolver),
                     state = new Entity('states'),
                     stateId = new Field('id').identifier(true),
                     character = new Entity('characters'),
@@ -210,69 +180,13 @@ define(function (require) {
                 spyOn(Restangular, 'getList').and.returnValue(mixins.buildPromise(mixins.buildPromise({data: rawCharacters})));
                 spyOn($q, 'all').and.returnValue(mixins.buildPromise([{data: rawCharacters}]));
 
-                retrieveQueries.getReferencedListValues(state.listView(), null, null, 1)
-                    .then(function (references) {
-                        var entries = dataStore.getEntries(stateCharacters.getReferencedView());
-
-                        expect(entries.length).toEqual(3);
-                        expect(entries[0].values.name).toEqual('Rollo');
-                        expect(entries[1].values.id).toEqual('19DFE');
+                retrieveQueries.getReferencedListData(state.listView().getReferencedLists(), null, null, 1)
+                    .then(function (referencedListData) {
+                        expect(referencedListData.character.length).toEqual(3);
+                        expect(referencedListData.character[0].name).toEqual('Rollo');
+                        expect(referencedListData.character[1].id).toEqual('19DFE');
                     })
                     .then(done, done.fail);
-            });
-        });
-
-        describe('fillReferencesValuesFromCollection', function() {
-            it('should fill reference values of a collection', function () {
-                var retrieveQueries = new RetrieveQueries({}, Restangular, config, dataStore, PromisesResolver),
-                    entry1 = new Entry(),
-                    entry2 = new Entry(),
-                    entry3 = new Entry(),
-                    human = new Entity('humans'),
-                    tag = new Entity('tags'),
-                    ref1 = new ReferenceField('human_id'),
-                    ref2 = new ReferenceManyField('tags');
-
-                human.editionView().identifier(new Field('id'));
-                tag.editionView().identifier(new Field('id'));
-                ref1
-                    .targetEntity(human)
-                    .targetField(new Field('name'));
-                dataStore.setEntries(ref1.getReferencedView(), [
-                    {values: {id: 1, name: 'Bob'}},
-                    {values: {id: 2, name: 'Daniel'}},
-                    {values: {id: 3, name: 'Jack'}}
-                ]);
-
-                ref2
-                    .targetEntity(tag)
-                    .targetField(new Field('label'));
-                dataStore.setEntries(ref2.getReferencedView(), [
-                    {values: {id: 1, label: 'Photo'}},
-                    {values: {id: 2, label: 'Watch'}},
-                    {values: {id: 3, label: 'Panda'}}
-                ]);
-
-                entry1.values.human_id = 1;
-                entry1.values.tags = [1, 3];
-                entry2.values.human_id = 1;
-                entry2.values.tags = [2];
-                entry3.values.human_id = 3;
-
-                var collection = [entry1, entry2, entry3];
-                var referencedValues = {
-                    human_id: ref1,
-                    tags: ref2
-                };
-
-                collection = dataStore.fillReferencesValuesFromCollection(collection, referencedValues, true);
-
-                expect(collection.length).toEqual(3);
-                expect(collection[0].listValues.human_id).toEqual('Bob');
-                expect(collection[0].listValues.tags).toEqual(['Photo', 'Panda']);
-                expect(collection[1].listValues.tags).toEqual(['Watch']);
-                expect(collection[2].listValues.human_id).toEqual('Jack');
-                expect(collection[2].listValues.tags).toEqual([]);
             });
         });
 
@@ -307,18 +221,18 @@ define(function (require) {
                     }
                 }));
 
-                var retrieveQueries = new RetrieveQueries({}, Restangular, config, dataStore, PromisesResolver);
+                var retrieveQueries = new RetrieveQueries({}, Restangular, config, PromisesResolver);
 
                 retrieveQueries.getOne(view, 1)
-                    .then(function (entry) {
+                    .then(function (rawEntry) {
                         expect(Restangular.oneUrl).toHaveBeenCalledWith('cat', 'http://localhost/cat/1');
                         expect(Restangular.get).toHaveBeenCalledWith();
-                        expect(entry.identifierValue).toBe(1);
-                        expect(entry.values.id).toBe(1);
-                        expect(entry.values.name).toBe('Mizoute');
+
+                        expect(rawEntry.id).toBe(1);
+                        expect(rawEntry.name).toBe('Mizoute');
 
                         // Non mapped field should also be retrieved
-                        expect(entry.values.summary).toBe("A Cat");
+                        expect(rawEntry.summary).toBe("A Cat");
                     })
                     .then(done, done.fail);
             });

--- a/src/javascripts/test/unit/Crud/repository/UpdateQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/UpdateQueriesSpec.js
@@ -14,8 +14,6 @@ define(function (require) {
         entity,
         view;
 
-    var dataStore = new DataStore();
-
     describe("Service: UpdateQueries", function () {
 
         beforeEach(function () {
@@ -40,16 +38,19 @@ define(function (require) {
         describe("updateOne", function () {
 
             it('should PUT an entity when calling updateOne', function (done) {
-                var updateQueries = new UpdateQueries({}, Restangular, config, dataStore),
+                var updateQueries = new UpdateQueries({}, Restangular, config),
                     rawEntity = {id: 3, name: 'Mizu'};
 
                 spyOn(Restangular, 'oneUrl').and.callThrough();
                 spyOn(Restangular, 'customPUT').and.returnValue(mixins.buildPromise({data: rawEntity}));
 
                 updateQueries.updateOne(view, rawEntity)
-                    .then(function (entry) {
+                    .then(function (rawEntry) {
                         expect(Restangular.oneUrl).toHaveBeenCalledWith('cat', 'http://localhost/cat/3');
                         expect(Restangular.customPUT).toHaveBeenCalledWith(rawEntity);
+
+                        var dataStore = new DataStore();
+                        var entry = dataStore.mapEntry(entity.name(), view.identifier(), view.getFields(), rawEntry);
                         expect(entry.values.name).toEqual('Mizu');
                     })
                     .then(done, done.fail);

--- a/src/javascripts/test/unit/Crud/repository/UpdateQueriesSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/UpdateQueriesSpec.js
@@ -7,11 +7,14 @@ define(function (require) {
         Field = require('ng-admin/es6/lib/Field/Field'),
         TextField = require('ng-admin/es6/lib/Field/TextField'),
         Entity = require('ng-admin/es6/lib/Entity/Entity'),
+        DataStore = require('ng-admin/es6/lib/DataStore/DataStore'),
         Restangular = require('mock/Restangular'),
         mixins = require('mixins'),
         config,
         entity,
         view;
+
+    var dataStore = new DataStore();
 
     describe("Service: UpdateQueries", function () {
 
@@ -37,7 +40,7 @@ define(function (require) {
         describe("updateOne", function () {
 
             it('should PUT an entity when calling updateOne', function (done) {
-                var updateQueries = new UpdateQueries({}, Restangular, config),
+                var updateQueries = new UpdateQueries({}, Restangular, config, dataStore),
                     rawEntity = {id: 3, name: 'Mizu'};
 
                 spyOn(Restangular, 'oneUrl').and.callThrough();

--- a/src/javascripts/test/unit/Main/component/service/PanelBuilderSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/PanelBuilderSpec.js
@@ -6,6 +6,8 @@ define(function (require) {
     var PanelBuilder = require('ng-admin/Main/component/service/PanelBuilder'),
         Field = require('ng-admin/es6/lib/Field/Field'),
         DashboardView = require('ng-admin/es6/lib/View/DashboardView'),
+        Entity = require('ng-admin/es6/lib/Entity/Entity'),
+        DataStore = require('ng-admin/es6/lib/DataStore/DataStore'),
         mixins = require('mixins');
 
     describe("PanelBuilder", function () {
@@ -13,24 +15,27 @@ define(function (require) {
         describe('getPanelsData', function() {
 
             it('should retrieve panels', function (done) {
-                var view1 = new DashboardView('view1')
+                var entity = new Entity(),
+                    view1 = new DashboardView('view1')
                         .title('dashboard1')
+                        .setEntity(entity)
                         .addField(new Field('title').label('Title')),
                     view2 = new DashboardView('MyView2')
                         .title('my dashboard 2')
+                        .setEntity(entity)
                         .addField(new Field('name').label('Name'));
 
                 var responses = [
                     {
                         view: view1,
-                        entries: [],
+                        data: [],
                         currentPage: 1,
                         perPage: 10,
                         totalItems: 12
                     },
                     {
                         view: view2,
-                        entries: [],
+                        data: [],
                         currentPage: 1,
                         perPage: 10,
                         totalItems: 4
@@ -53,13 +58,11 @@ define(function (require) {
 
             it('should default to entity label if no title is provided', function(done) {
                 var dashboardView = new DashboardView('view1').addField(new Field('title').label('Title'));
-                dashboardView.setEntity({
-                    label: function() { return "Entity"; }
-                });
+                dashboardView.setEntity(new Entity('MyEntity'));
 
                 var response = {
                     view: dashboardView,
-                    entries: [],
+                    data: [],
                     currentPage: 1,
                     perPage: 10,
                     totalItems: 12
@@ -68,7 +71,7 @@ define(function (require) {
                 var panelBuilder = getPanelBuilder([dashboardView], [response]);
                 panelBuilder.getPanelsData()
                     .then(function(panels) {
-                        expect(panels[0].label).toBe('Entity');
+                        expect(panels[0].label).toBe('MyEntity');
                     })
                     .finally(done);
             });
@@ -87,7 +90,8 @@ define(function (require) {
         };
         var location = { search: function() { return {}; } };
         var retrieveQueries = { getAll: function() {} };
+        var AdminDescription = { getDataStore: function() { return new DataStore(); } };
 
-        return new PanelBuilder(q, filter, location, retrieveQueries, Configuration);
+        return new PanelBuilder(q, filter, location, retrieveQueries, Configuration, AdminDescription);
     }
 });

--- a/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
@@ -4,8 +4,11 @@ define(function (require) {
     'use strict';
 
     var ListView = require('ng-admin/es6/lib/View/ListView'),
+        DataStore = require('ng-admin/es6/lib/DataStore/DataStore'),
         Entity = require('ng-admin/es6/lib/Entity/Entity'),
         Field = require('ng-admin/es6/lib/Field/Field');
+
+    var dataStore = new DataStore();
 
     describe("Service: ListView config", function () {
 
@@ -31,8 +34,7 @@ define(function (require) {
                         return value.substr(0, 5) + '...';
                     }));
 
-
-                var entries = list.mapEntries([
+                var entries = dataStore.mapEntries(list, [
                     { id: 1, human_id: 1, name: 'Suna'},
                     { id: 2, human_id: 2, name: 'Boby'},
                     { id: 3, human_id: 1, name: 'Mizute'}

--- a/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
@@ -34,7 +34,7 @@ define(function (require) {
                         return value.substr(0, 5) + '...';
                     }));
 
-                var entries = dataStore.mapEntries(list, [
+                var entries = dataStore.mapEntries(list.entity.name(), list.identifier(), list.getFields(), [
                     { id: 1, human_id: 1, name: 'Suna'},
                     { id: 2, human_id: 2, name: 'Boby'},
                     { id: 3, human_id: 1, name: 'Mizute'}


### PR DESCRIPTION
* [x] Create DataStore to sotre all entries related to views
* [x] Remove `View.entries` property
* [x] Move `mapEntry(ies)` from View
* [x] ~~Remove Views created by code for references~~
* [x] Fix (and add ?) tests

Result of this refactoring:
* `RetrieveQueries` does not deal anymore with `Entry`
* `DataStore` now store all entries, references and filter values
* `mapEntry` is now done by `DataStore`
* `routing.js` now explicitly create and map entries
* `ReferenceField` does not extend `ChoiceField` anymore