### PR TITLE
[RFR] Fix relative baseApiUrl gets doubled in the URL

### DIFF
--- a/src/javascripts/ng-admin/es6/lib/Application.js
+++ b/src/javascripts/ng-admin/es6/lib/Application.js
@@ -2,7 +2,7 @@ import Menu from './Menu/Menu';
 
 class Application {
     constructor(title='ng-admin') {
-        this._baseApiUrl = null;
+        this._baseApiUrl = '';
         this._customTemplate = function(viewName) {};
         this._title = title;
         this._menu = null;
@@ -41,10 +41,8 @@ class Application {
             if (entityId) {
                 url += '/' + entityId;
             }
-        }
-
-        // Add baseUrl for relative URL
-        if (!/^(?:[a-z]+:)?\/\//.test(url)) {
+        } else if (!/^(?:[a-z]+:)?\/\//.test(url)) {
+            // Add baseUrl for relative URL
             url = baseApiUrl + url;
         }
 

--- a/src/javascripts/ng-admin/es6/tests/lib/ApplicationTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/ApplicationTest.js
@@ -4,6 +4,85 @@ import Application from "../../lib/Application";
 import Entity from "../../lib/Entity/Entity";
 
 describe('Application', function() {
+    describe('getRouteFor', function() {
+        it('should return entity name by default', function() {
+            var application = new Application();
+            var entity = new Entity('posts');
+            application.addEntity(entity);
+            assert.equal('posts', application.getRouteFor(entity.listView()));
+            assert.equal('posts/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use the application baseApiUrl when provided', function() {
+            var application = new Application();
+            application.baseApiUrl('/foo/');
+            var entity = new Entity('posts');
+            application.addEntity(entity);
+            assert.equal('/foo/posts', application.getRouteFor(entity.listView()));
+            assert.equal('/foo/posts/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use the entity baseApiUrl when provided', function() {
+            var application = new Application();
+            var entity = new Entity('posts');
+            entity.baseApiUrl('/bar/');
+            application.addEntity(entity);
+            assert.equal('/bar/posts', application.getRouteFor(entity.listView()));
+            assert.equal('/bar/posts/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use the entity baseApiUrl when both the application and entity baseApiUrl are provided', function() {
+            var application = new Application();
+            application.baseApiUrl('/foo/');
+            var entity = new Entity('posts');
+            entity.baseApiUrl('/bar/');
+            application.addEntity(entity);
+            assert.equal('/bar/posts', application.getRouteFor(entity.listView()));
+            assert.equal('/bar/posts/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use the entity url string when provided', function() {
+            var application = new Application();
+            var entity = new Entity('posts');
+            entity.url('/bar/baz');
+            application.addEntity(entity);
+            assert.equal('/bar/baz', application.getRouteFor(entity.listView()));
+            assert.equal('/bar/baz', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use the entity url function when provided', function() {
+            var application = new Application();
+            var entity = new Entity('posts');
+            entity.url(function(view, entityId) {
+                return '/bar/baz' + (entityId ? ('/' + entityId * 2) : '');
+            });
+            application.addEntity(entity);
+            assert.equal('/bar/baz', application.getRouteFor(entity.listView()));
+            assert.equal('/bar/baz/24', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use both the baseApiUrl and the entity url if the entity url is relative', function() {
+            var application = new Application();
+            application.baseApiUrl('/foo/');
+            var entity = new Entity('posts');
+            entity.url(function(view, entityId) { return 'bar/baz' + (entityId ? ('/' + entityId) : ''); });
+            application.addEntity(entity);
+            assert.equal('/foo/bar/baz', application.getRouteFor(entity.listView()));
+            assert.equal('/foo/bar/baz/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+        it('should use only the entity url if the entity url is absolute', function() {
+            var application = new Application();
+            application.baseApiUrl('/foo/');
+            var entity = new Entity('posts');
+            entity.url(function(view, entityId) { return 'http://bar/baz' + (entityId ? ('/' + entityId) : ''); });
+            application.addEntity(entity);
+            assert.equal('http://bar/baz', application.getRouteFor(entity.listView()));
+            assert.equal('http://bar/baz/12', application.getRouteFor(entity.listView(), 12));
+        });
+
+    });
+
     describe('getViewsOfType', function() {
         it('should return empty array if no entity set', function() {
             var application = new Application();


### PR DESCRIPTION
`baseApiUrl('/social/')` used to add the `/social/` prefix twice. Only absolute URLs (starting with `http://`) were added once.

Closes #405