### PR TITLE
added custom HTTP-Methods for create and update

### DIFF
--- a/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
@@ -26,8 +26,8 @@ define(function (require) {
     CreateQueries.prototype.createOne = function (view, rawEntity) {
 
         var method = view.entity.createMethod(),
-            url = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(), view.type)),
-            operation = method ? url.customOperation(method, null, {}, {}, rawEntity) : url.customPOST(rawEntity);
+            resource = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(), view.type)),
+            operation = method ? resource.customOperation(method, null, {}, {}, rawEntity) : resource.customPOST(rawEntity);
 
         return operation.then(function (response) {
             return response.data;

--- a/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/CreateQueries.js
@@ -24,12 +24,14 @@ define(function (require) {
      * @returns {promise}  the new object
      */
     CreateQueries.prototype.createOne = function (view, rawEntity) {
-        return this.Restangular
-            .oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(), view.type))
-            .customPOST(rawEntity)
-            .then(function (response) {
-                return response.data;
-            });
+
+        var method = view.entity.createMethod(),
+            url = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(), view.type)),
+            operation = method ? url.customOperation(method, null, {}, {}, rawEntity) : url.customPOST(rawEntity);
+
+        return operation.then(function (response) {
+            return response.data;
+        });
     };
 
     CreateQueries.$inject = ['$q', 'Restangular', 'NgAdminConfiguration', 'PromisesResolver'];

--- a/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
@@ -27,8 +27,8 @@ define(function (require) {
     UpdateQueries.prototype.updateOne = function (view, rawEntity, originEntityId) {
         var entityId = originEntityId || rawEntity[view.getEntity().identifier().name()],
             method = view.entity.updateMethod(),
-            url = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier())),
-            operation = method ? url.customOperation(method, null, {}, {}, rawEntity) : url.customPUT(rawEntity);
+            resource = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier())),
+            operation = method ? resource.customOperation(method, null, {}, {}, rawEntity) : resource.customPUT(rawEntity);
 
         // Get element data
         return operation

--- a/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
+++ b/src/javascripts/ng-admin/Crud/repository/UpdateQueries.js
@@ -25,12 +25,13 @@ define(function (require) {
      * @returns {promise} the updated object
      */
     UpdateQueries.prototype.updateOne = function (view, rawEntity, originEntityId) {
-        var entityId = originEntityId || rawEntity[view.getEntity().identifier().name()];
+        var entityId = originEntityId || rawEntity[view.getEntity().identifier().name()],
+            method = view.entity.updateMethod(),
+            url = this.Restangular.oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier())),
+            operation = method ? url.customOperation(method, null, {}, {}, rawEntity) : url.customPUT(rawEntity);
 
         // Get element data
-        return this.Restangular
-            .oneUrl(view.entity.name(), this.config.getRouteFor(view.entity, view.getUrl(entityId), view.type, entityId, view.identifier()))
-            .customPUT(rawEntity)
+        return operation
             .then(function (response) {
                 return response.data;
             });

--- a/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
+++ b/src/javascripts/ng-admin/es6/lib/Entity/Entity.js
@@ -23,6 +23,8 @@ class Entity {
         this._errorMessage = null;
         this._order = 0;
         this._url = null;
+        this._createMethod = null; // manually set the HTTP-method for create operation, defaults to POST
+        this._updateMethod = null; // manually set the HTTP-method for update operation, defaults to PUT
 
         this._initViews();
     }
@@ -123,6 +125,18 @@ class Entity {
     baseApiUrl(baseApiUrl) {
         if (!arguments.length) return this._baseApiUrl;
         this._baseApiUrl = baseApiUrl;
+        return this;
+    }
+
+    createMethod(createMethod) {
+        if (!arguments.length) return this._createMethod;
+        this._createMethod = createMethod;
+        return this;
+    }
+
+    updateMethod(updateMethod) {
+        if (!arguments.length) return this._updateMethod;
+        this._updateMethod = updateMethod;
         return this;
     }
 

--- a/src/javascripts/ng-admin/es6/tests/lib/Entity/EntityTest.js
+++ b/src/javascripts/ng-admin/es6/tests/lib/Entity/EntityTest.js
@@ -58,4 +58,28 @@ describe('Entity', function() {
             assert.equal(false, entity.deletionView().enabled);
         });
     })
+
+    describe('createMethod', function() {
+        it('should return given createMethod if already set', function() {
+            var post = new Entity('post').createMethod('PUT');
+            assert.equal('PUT', post.createMethod());
+        });
+
+        it('should return null if no createMethod has been set', function() {
+            var post = new Entity('post');
+            assert.equal(null, post.createMethod());
+        });
+    });
+
+    describe('updateMethod', function() {
+        it('should return given updateMethod if already set', function() {
+            var post = new Entity('post').updateMethod('POST');
+            assert.equal('POST', post.updateMethod());
+        });
+
+        it('should return null if no updateMethod has been set', function() {
+            var post = new Entity('post');
+            assert.equal(null, post.updateMethod());
+        });
+    });
 });


### PR DESCRIPTION
Hi,

for a current task I need the possibility to set a custom HTTP method for a create operation, in my case 'put' instead of 'post'. I saw a similar request in #362.  

I gave it a try in this pull request.  The change I did works for me, so please consider merging if you think this is a useful addition.

If you think another approach for the same goal is better just get back to me.
I also tried to add tests for this in CreateQueriesSpec.js and UpdateQueriesSpec.js but couldn't figure out to set the xxxMethod on the entity. So, if you could give me a hint I will add this as well.

Kind regards,
Matthias