### PR TITLE
[RFR] Stay on Angularjs 1.3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "admin-config": "^0.1.3",
-    "angular": "^1.3.15",
+    "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-file-upload": "^1.6.4",
     "angular-mocks": "^1.3.15",


### PR DESCRIPTION
I suggest to stay on AngularJS 1.3 as 1.4 breaks many things in ng-admin core and project using it (custom directive for example).
Because ng-admin embed by default the AngularJS dependency, all projects will be updated to the 1.4 version, and this will probably broke something.