### PR TITLE
[RFR] Fix BC issue with step attribute

### DIFF
--- a/src/javascripts/ng-admin/Crud/field/maInputField.js
+++ b/src/javascripts/ng-admin/Crud/field/maInputField.js
@@ -24,6 +24,11 @@ define(function (require) {
                 var input = element.children()[0];
                 var attributes = field.attributes();
                 for (var name in attributes) {
+                    if (name === 'step') { // allow to use `step` attribute instead of `scope.step`
+                        scope.step = attributes[name];
+                        continue;
+                    }
+
                     input[name] = attributes[name];
                 }
             },

--- a/src/javascripts/test/unit/Crud/field/maInputFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maInputFieldSpec.js
@@ -59,4 +59,11 @@ describe('directive: input-field', function () {
         scope.$digest();
         expect(element.find('input').val()).toBe('baz');
     });
+
+    it('should set `step` attribute in scope if passed as element attribute', function() {
+        scope.field = new Field().attributes({ step: 'any' });
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.find('input')[0].step).toBe('any');
+    });
 });


### PR DESCRIPTION
Adding `float` type introduced a backward compatibility issue. As new `ma-input` directive now has a `ng-attr-step` attribute, it skipped the `step` attribute set through the `Field.attributes()` method.

This PR fixes it, allowing the following code:

``` js
nga.filter('count', 'number').attributes({ step: 'any' }).format('0.000');
```

To be equivalent to:

``` js
nga.filter('count', 'float');
```