### PR TITLE
Update build to fix issues on MacOS (fixes #515)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run:
 
 build:
 	@NODE_ENV=production ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe --progress
-	@cp -Rf build/* examples/blog/build/
+	@cp -Rf build examples/blog/
 	@echo "Files build/ng-admin.min.css and build/ng-admin.min.js updated (with minification)"
 
 test:


### PR DESCRIPTION
Issue especially happens when the folder `examples/blog/build` doesn't exist. Linux created it automatically, but not MacOS.