### PR TITLE
[WIP] Batch delete with single api call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,5 @@ build:
 	@cp -Rf build examples/blog/
 	@echo "Files build/ng-admin.min.css and build/ng-admin.min.js updated (with minification)"
 
-build-dev:
-	@NODE_ENV=production ./node_modules/webpack/bin/webpack.js --progress
-
 test:
 	@grunt test:local

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ build:
 	@cp -Rf build examples/blog/
 	@echo "Files build/ng-admin.min.css and build/ng-admin.min.js updated (with minification)"
 
+build-dev:
+	@NODE_ENV=production ./node_modules/webpack/bin/webpack.js --progress
+
 test:
 	@grunt test:local

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ If your API does not support `_filters` parameter but `posts_filter` (for exampl
             return { params: params };
         });
 
-But the most classic need will be to recover server side table an array of ids.   
+The most common use-case is to send an array of ids to server:   
 
         // Will call  /posts?post_id[]=1&post_id[]=2&post_id%[]=5...
         post.batchDeleteView()
@@ -766,7 +766,7 @@ If your API does not support `_filters` parameter but `posts_filter` (for exampl
             return { params: params };
         });
 
-But the most classic need will be to recover server side table an array of ids.         
+But the most common use-case is to send an array of ids to server:         
 
         // Will call /posts?post_id[]=1&post_id[]=2&post_id[]=5...
         commentList.fields([

--- a/README.md
+++ b/README.md
@@ -394,6 +394,18 @@ Set the fields for the CSV export function. By default, ng-admin uses the fields
                 .stripTags(true)
         ]);
 
+
+### batchDeleteView Settings
+
+* `singleApiCall(function(entityIds) {}`
+By default, the batch delete action make as many requests as you selected objects. If you want to delete all selected objects in a single request, you have to define a `singleApiCall` function. You can use it if you API support filter for multiple values on a DELETE request.
+
+        // Will call DELETE /posts?id[]=1&id[]=2&id%[]=5...
+        post.batchDeleteView()
+          .singleApiCall(function (ids) {
+            return { 'id[]': ids };
+          });
+
 ## Fields
 
 A field is the representation of a property of an entity. 

--- a/README.md
+++ b/README.md
@@ -397,14 +397,51 @@ Set the fields for the CSV export function. By default, ng-admin uses the fields
 
 ### batchDeleteView Settings
 
-* `singleApiCall(function(entityIds) {}`
+* `singleApiCall(function(entityIds) {})`
+
 By default, the batch delete action make as many requests as you selected objects. If you want to delete all selected objects in a single request, you have to define a `singleApiCall` function. You can use it if you API support filter for multiple values on a DELETE request.
 
-        // Will call DELETE /posts?id[]=1&id[]=2&id%[]=5...
+        // Will call DELETE /posts?_filters=id1,id2,.._
         post.batchDeleteView()
-          .singleApiCall(function (ids) {
-            return { 'id[]': ids };
+            .singleApiCall(function (ids) {
+            return postIds.join(,);
+        });
+
+If your API does not support `_filters` parameter but `posts_filter` (for example), you will have to configure a Restangular interceptor : 
+
+        // Will call DELETE /posts?posts_filter=id1,id2,.._
+        RestangularProvider.addFullRequestInterceptor(function(element, operation, what, url, headers, params) {
+            if (operation == "remove") {
+                if (params._filters) {
+                    params.posts_filter = params._filters; 
+                    delete params._filters;
+                }
+            }
+            return { params: params };
+        });
+
+But the most classic need will be to recover server side table an array of ids.   
+
+        // Will call  /posts?post_id[]=1&post_id[]=2&post_id%[]=5...
+        post.batchDeleteView()
+            .singleApiCall(function (ids) {
+                return { 'post_id[]': postIds };
+            });
+
+With a Restangular interceptor as :
+
+          RestangularProvider.addFullRequestInterceptor(function(element, operation, what, url, headers, params) {
+              if (operation == "remove") {
+                  if (params._filters) {
+                      for (var filter in params._filters) {
+                          params[filter] = params._filters[filter];
+                      }
+                      delete params._filters;
+                  }
+              }
+              return { params: params };
           });
+
 
 ## Fields
 
@@ -705,16 +742,53 @@ Define the target field name used to retrieve the label of the referenced elemen
                 .targetField(nga.field('title')) // Select a label Field
         ]);
         
-* `singleApiCall(function(entityIds) {}`
+* `singleApiCall(function(entityIds) {})`
+
 Define a function that returns parameters for filtering API calls. You can use it if you API support filter for multiple values.
 
-		// Will call /posts?post_id[]=1&post_id[]=2&post_id%[]=5...
+		// Will call /posts?_filters=id1,id2,.._
 		commentList.fields([
+            nga.field('post_id', 'reference')
+                .singleApiCall(function (postIds) {
+                    return postIds.join(,);
+                })
+        ]);
+
+If your API does not support `_filters` parameter but `posts_filter` (for example), you will have to configure a Restangular interceptor : 
+
+        RestangularProvider.addFullRequestInterceptor(function(element, operation, what, url, headers, params) {
+            if (operation == "getList") {
+                if (params._filters) {
+                    params.posts_filter = params._filters;             
+                    delete params._filters;
+                }
+            }
+            return { params: params };
+        });
+
+But the most classic need will be to recover server side table an array of ids.         
+
+        // Will call /posts?post_id[]=1&post_id[]=2&post_id[]=5...
+        commentList.fields([
             nga.field('post_id', 'reference')
                 .singleApiCall(function (postIds) {
                     return { 'post_id[]': postIds };
                 })
         ]);
+
+With a Restangular interceptor as :
+
+        RestangularProvider.addFullRequestInterceptor(function(element, operation, what, url, headers, params) {
+            if (operation == "getList") {
+                if (params._filters) {
+                    for (var filter in params._filters) {
+                        params[filter] = params._filters[filter];
+                    }
+                    delete params._filters;
+                }
+            }
+            return { params: params };
+        });
 
 * `sortField(String)`
 Set the default field for list sorting. Defaults to 'id'

--- a/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
@@ -12,12 +12,6 @@ define(function () {
         this.view = view;
         this.entity = view.getEntity();
         this.entityIds = $state.params.ids;
-        this.selection = []; // fixme: query db to get selection
-        this.title = view.title();
-        this.description = view.description();
-        this.actions = view.actions();
-        this.loadingPage = false;
-        this.fields = view.fields();
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };

--- a/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
@@ -12,11 +12,14 @@ define(function () {
         this.view = view;
         this.entity = view.getEntity();
         this.entityIds = $state.params.ids;
+        this.alreadyConfirm = false;
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };
 
     BatchDeleteController.prototype.batchDelete = function () {
+        if (this.alreadyConfirm) return false;
+        this.alreadyConfirm = true;
         var notification = this.notification,
             $state = this.$state,
             entityName = this.entity.name();

--- a/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
@@ -12,14 +12,14 @@ define(function () {
         this.view = view;
         this.entity = view.getEntity();
         this.entityIds = $state.params.ids;
-        this.alreadyConfirm = false;
+        this.confirmed = false;
 
         $scope.$on('$destroy', this.destroy.bind(this));
     };
 
     BatchDeleteController.prototype.batchDelete = function () {
-        if (this.alreadyConfirm) return false;
-        this.alreadyConfirm = true;
+        if (this.confirmed) return false;
+        this.confirmed = true;
         var notification = this.notification,
             $state = this.$state,
             entityName = this.entity.name();

--- a/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
+++ b/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
@@ -60,13 +60,13 @@ define(function () {
 
     RestWrapper.prototype.deleteOne = function(entityName, url) {
         return this.Restangular
-        .oneUrl(entityName, url)
+            .oneUrl(entityName, url)
             .customDELETE();
     };
 
     RestWrapper.prototype.deleteAll = function(entityName, url, params) {
         return this.Restangular
-        .oneUrl(entityName, url)
+            .oneUrl(entityName, url)
             .remove(params);
     };
 

--- a/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
+++ b/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
@@ -67,7 +67,7 @@ define(function () {
     RestWrapper.prototype.deleteAll = function(entityName, url, params) {
         return this.Restangular
         .oneUrl(entityName, url)
-            .customDELETE(null, params);
+            .remove(params);
     };
 
     RestWrapper.$inject = ['Restangular'];

--- a/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
+++ b/src/javascripts/ng-admin/Crud/misc/RestWrapper.js
@@ -64,6 +64,12 @@ define(function () {
             .customDELETE();
     };
 
+    RestWrapper.prototype.deleteAll = function(entityName, url, params) {
+        return this.Restangular
+        .oneUrl(entityName, url)
+            .customDELETE(null, params);
+    };
+
     RestWrapper.$inject = ['Restangular'];
 
     return RestWrapper;


### PR DESCRIPTION
We need, in 1859 project, to be able to batch delete multiple objects in a single call. 
With this PR, we will be able to set a singleApiCall function to the BatchDeleteView and then, create a single request to delete objects in API (with a DELETE request on /objects?id[]=1&id[]=2&id[]=5)

It follow another PR on admin-config : https://github.com/marmelab/admin-config/pull/22

- [ ] : allow a default url as /posts?post_id[]=1&post_id[]=2&... without interceptor