### PR TITLE
[RFR] Delete view: back to previous state, not edit or list view

### DIFF
--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -3,7 +3,7 @@
 define(function () {
     'use strict';
 
-    var DeleteController = function ($scope, $state, WriteQueries, notification, params, view, entry) {
+    var DeleteController = function ($scope, $window, $state, WriteQueries, notification, params, view, entry) {
         this.$scope = $scope;
         this.$state = $state;
         this.WriteQueries = WriteQueries;
@@ -17,6 +17,7 @@ define(function () {
         this.notification = notification;
         this.$scope.entry = entry;
         this.$scope.view = view;
+        this.goBack = function(){ $window.history.back(); }
         $scope.$on('$destroy', this.destroy.bind(this));
     };
 
@@ -26,10 +27,7 @@ define(function () {
 
         this.WriteQueries.deleteOne(this.view, this.entityId).then(function () {
 
-            $state.go($state.get('list'), angular.extend({
-                entity: entityName,
-                id: this.entityId
-            }, $state.params));
+            this.goBack();
             notification.log('Element successfully deleted.', { addnCls: 'humane-flatty-success' });
         }.bind(this), function (response) {
             // @TODO: share this method when splitting controllers
@@ -43,12 +41,7 @@ define(function () {
     };
 
     DeleteController.prototype.back = function () {
-        var $state = this.$state;
-
-        $state.go($state.get('edit'), angular.extend({
-            entity: this.entity.name(),
-            id: this.entityId
-        }, $state.params));
+        this.goBack();
     };
 
     DeleteController.prototype.destroy = function () {
@@ -59,7 +52,7 @@ define(function () {
         this.entity = undefined;
     };
 
-    DeleteController.$inject = ['$scope', '$state', 'WriteQueries', 'notification', 'params', 'view', 'entry'];
+    DeleteController.$inject = ['$scope', '$window', '$state', 'WriteQueries', 'notification', 'params', 'view', 'entry'];
 
     return DeleteController;
 });

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -3,9 +3,9 @@
 define(function () {
     'use strict';
 
-    var DeleteController = function ($scope, $window, $state, WriteQueries, notification, params, view, entry) {
+    var DeleteController = function ($scope, $window, WriteQueries, notification, params, view, entry) {
         this.$scope = $scope;
-        this.$state = $state;
+        this.$window = $window;
         this.WriteQueries = WriteQueries;
         this.entityLabel = params.entity;
         this.entityId = params.id;
@@ -17,17 +17,16 @@ define(function () {
         this.notification = notification;
         this.$scope.entry = entry;
         this.$scope.view = view;
-        this.goBack = function(){ $window.history.back(); }
         $scope.$on('$destroy', this.destroy.bind(this));
     };
 
     DeleteController.prototype.deleteOne = function () {
         var notification = this.notification,
-            $state = this.$state, entityName = this.entity.name();
+            entityName = this.entity.name(),
+            $window = this.$window;
 
         this.WriteQueries.deleteOne(this.view, this.entityId).then(function () {
-
-            this.goBack();
+            $window.history.back();
             notification.log('Element successfully deleted.', { addnCls: 'humane-flatty-success' });
         }.bind(this), function (response) {
             // @TODO: share this method when splitting controllers
@@ -41,18 +40,19 @@ define(function () {
     };
 
     DeleteController.prototype.back = function () {
-        this.goBack();
+        var $window = this.$window;
+
+        $window.history.back();
     };
 
     DeleteController.prototype.destroy = function () {
         this.$scope = undefined;
         this.WriteQueries = undefined;
-        this.$state = undefined;
         this.view = undefined;
         this.entity = undefined;
     };
 
-    DeleteController.$inject = ['$scope', '$window', '$state', 'WriteQueries', 'notification', 'params', 'view', 'entry'];
+    DeleteController.$inject = ['$scope', '$window', 'WriteQueries', 'notification', 'params', 'view', 'entry'];
 
     return DeleteController;
 });

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -26,7 +26,7 @@ define(function () {
             $window = this.$window;
 
         this.WriteQueries.deleteOne(this.view, this.entityId).then(function () {
-            $window.history.back();
+            this.back();
             notification.log('Element successfully deleted.', { addnCls: 'humane-flatty-success' });
         }.bind(this), function (response) {
             // @TODO: share this method when splitting controllers
@@ -40,9 +40,7 @@ define(function () {
     };
 
     DeleteController.prototype.back = function () {
-        var $window = this.$window;
-
-        $window.history.back();
+        this.$window.history.back();
     };
 
     DeleteController.prototype.destroy = function () {

--- a/src/javascripts/test/e2e/ListViewSpec.js
+++ b/src/javascripts/test/e2e/ListViewSpec.js
@@ -66,11 +66,6 @@ describe('ListView', function () {
             }).then(function (elements) {
                 return elements[0].click();
             }).then(function() {
-                expect(browser.getCurrentUrl()).toBe(browser.baseUrl + '/#/comments/edit/2');
-                return $$('ma-list-button a');
-            }).then(function (elements) {
-                return elements[0].click();
-            }).then(function() {
                 expect(browser.getCurrentUrl()).toBe(listUrl);
             });
         });


### PR DESCRIPTION
If I press `Cancel` in *delete view* I want to go back where I came from, not to the deleted object's *edit view* (the delete button may be pressed in *list view* or in `referenced_list` field of other entity, not always in *edit view*; also *list view* or *edit view* or both may be disabled for deleted entity - than we would have an error). Same thing with after-delete-redirect.
I think it is much more logical to just redirect user to the previous entry in history, than to specifically *edit view* or *list view*. Is there some problems with this approach? I don't see any.