### PR TITLE
[RFR] Clarify Map logic, allow nested fields

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,8 @@ module.exports = function (grunt) {
                 options: {
                     port: 3000,
                     db: 'examples/blog/stub-server.json',
-                    keepalive: false
+                    keepalive: false,
+                    logger: false
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Tell if the value is a link in the list view. Default to true for the identifier
 Define the route for a link in the list view, i.e. `isDetailLink` of the field is true. The default is `edit`, hence the link points to the edition view. The other option is `show` to point to the show view.
 
 * `map(function)`
-Define a custom function to transform the value. It receive the value and the corresponding entry. Works in list, edit views and references.
+Define a custom function to transform the value received from the API response to the value displayed in the admin. This function receives 2 parameters: the value to transform, and the corresponding entry. Works in list, edit views and references.
 
         nga.field('characters')
             .map(function truncate(value, entry) {
@@ -445,6 +445,24 @@ Define a custom function to transform the value. It receive the value and the co
         nga.field('comment')
             .map(stripTags)
             .map(truncate);
+
+* `transform(function)`
+Define a custom function to transform the value displayed in the admin back to the one expected by the API. This function receives 2 parameters: the value to transform, and the corresponding entry. Used in edit view only. Use it in conjunction with `map()` to ease the conversion between the API response format and the format you want displayed on screen.
+
+        //           API
+        //   map()  v  ^  tranform()
+        //          Entry︎
+        //
+        // The API provides and expects last names in all caps, e.g. 'DOE'
+        // The admin should display them with capitalized last names, e.g 'Doe'
+        nga.field('last_name')
+            .map(function capitalize(value, entry) {
+                return value.substr(0,1).toUpperCase() + value.substr(1).toLowerCase()
+            })
+            .transform(function allCaps(value, entry) {
+                // the API expects upper case last names
+                return value.toUpperCase();
+            });
 
 * `validation(object)`
 Tell how to validate the view

--- a/UPGRADE-0.8.md
+++ b/UPGRADE-0.8.md
@@ -73,3 +73,26 @@ admin.dashboard(nga.dashboard()
 See the [Dashboard Configuration](doc/Dashboard.md) dedicated chapter for more details.
 
 Calls to `dashboardView()` are still supported in ng-admin 0.8, but will raise an error in future versions. 
+
+## `field.map()` callbacks no longer apply to POST and PUT queries
+
+Registering a transformation callback using `field.map()` used to be applied both ways: from the REST response to the Entry object used by ng-admin (in read queries using GET), and from the Entry object to the body of the REST requests (for write queries using POST and PUT). This didn't make sense, and prevented a proper use of this `map()` feature in the edition and creation view.
+
+Now `map()` only applies to read queries, and a symmetric feature called `transform()` was added to handle the transformation of ng-admin values from forms to REST requests.
+
+```js
+//   API
+//   map()  v  ^  tranform()
+//          Entry︎
+//
+// The API provides and expects last names in all caps, e.g. 'DOE'
+// The admin should display them with capitalized last names, e.g 'Doe'
+nga.field('last_name')
+    .map(function capitalize(value, entry) {
+        return value.substr(0,1).toUpperCase() + value.substr(1).toLowerCase()
+    })
+    .transform(function allCaps(value, entry) {
+        // the API expects upper case last names
+        return value.toUpperCase();
+    });
+```

--- a/doc/API-mapping.md
+++ b/doc/API-mapping.md
@@ -93,7 +93,7 @@ app.config(function(RestangularProvider) {
 ```js
 listView.fields([
     nga.field('name'),
-    nga.field('author.name').label('Author name')
+    nga.field('author.name')
 ])
 ```
 

--- a/doc/API-mapping.md
+++ b/doc/API-mapping.md
@@ -76,6 +76,27 @@ app.config(function(RestangularProvider) {
 }
 ```
 
+**Tip**: If you want to define a field mapped to a deeply nested property, you don't need an interceptor. Just define the field with a name made by the path to the property using dots as separators:
+
+```json
+{
+    "id": 12,
+    "name": "War and Peace",
+    "author": {
+        "id": 345,
+        "name": "Leo Tolstoi"
+    },
+    "publication_date": "2014-01-01T00:00:00Z"
+}
+```
+
+```js
+listView.fields([
+    nga.field('name'),
+    nga.field('author.name').label('Author name')
+])
+```
+
 ## Pagination
 
 ng-admin assumes that your API accepts `_page` and `_perPage` query parameters to paginate lists:

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -28,7 +28,9 @@
                 // custom sort params
                 if (params._sortField) {
                     params._sort = params._sortField;
+                    params._order = params._sortDir;
                     delete params._sortField;
+                    delete params._sortDir;
                 }
                 // custom filters
                 if (params._filters) {

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -155,7 +155,8 @@
             .fields([
                 nga.field('created_at', 'date')
                     .label('Posted'),
-                nga.field('author'),
+                nga.field('author.name')
+                    .label('Author'),
                 nga.field('body', 'wysiwyg')
                     .stripTags(true)
                     .map(truncate),
@@ -186,7 +187,8 @@
                 nga.field('created_at', 'date')
                     .label('Posted')
                     .defaultValue(new Date()), // preset fields in creation view with defaultValue
-                nga.field('author'),
+                nga.field('author.name')
+                    .label('Author'),
                 nga.field('body', 'wysiwyg'),
                 nga.field('post_id', 'reference')
                     .label('Post')

--- a/examples/blog/stub-server.json
+++ b/examples/blog/stub-server.json
@@ -183,78 +183,99 @@
   "comments": [
     {
       "id": 1,
-      "author": "Sigurd O'Conner",
+      "author": {},
       "post_id": 6,
       "body": "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
       "created_at": "2012-08-02"
     },
     {
       "id": 2,
-      "author": "Kiley Pouros",
+      "author": {
+        "name": "Kiley Pouros",
+        "email": "kiley@gmail.com"
+      },
       "post_id": 9,
       "body": "White Rabbit: it was indeed: she was out of the ground--and I should frighten them out of its right paw round, 'lives a March Hare. 'Sixteenth,'.",
       "created_at": "2012-08-08"
     },
     {
       "id": 3,
-      "author": "Justina Hegmann",
+      "author": {
+        "name": "Justina Hegmann"
+      },
       "post_id": 3,
       "body": "I'm not Ada,' she said, 'and see whether it's marked \"poison\" or.",
       "created_at": "2012-08-02"
     },
     {
       "id": 4,
-      "author": "Ms. Brionna Smitham MD",
+      "author": {
+        "name": "Ms. Brionna Smitham MD"
+      },
       "post_id": 6,
       "body": "Dormouse. 'Fourteenth of March, I think I can say.' This was such a noise inside, no one else seemed inclined.",
       "created_at": "2014-09-24"
     },
     {
       "id": 5,
-      "author": "Edmond Schulist",
+      "author": {
+        "name": "Edmond Schulist"
+      },
       "post_id": 1,
       "body": "I ought to tell me your history, you know,' the Hatter and the happy summer days. THE.",
       "created_at": "2012-08-07"
     },
     {
       "id": 6,
-      "author": "Danny Greenholt",
+      "author": {
+        "name": "Danny Greenholt"
+      },
       "post_id": 6,
       "body": "Duchess asked, with another hedgehog, which seemed to be lost: away went Alice after it, never once considering how in the other. In the very tones of.",
       "created_at": "2012-08-09"
     },
     {
       "id": 7,
-      "author": "Luciano Berge",
+      "author": {
+        "name": "Luciano Berge"
+      },
       "post_id": 5,
       "body": "While the Panther were sharing a pie--' [later editions continued as follows.",
       "created_at": "2012-09-06"
     },
     {
       "id": 8,
-      "author": "Annamarie Mayer",
+      "author": {
+        "name": "Annamarie Mayer"
+      },
       "post_id": 5,
       "body": "I tell you, you coward!' and at once and put it more clearly,' Alice.",
       "created_at": "2012-10-03"
     },
     {
       "id": 9,
-      "author": "Breanna Gibson",
+      "author": {
+        "name": "Breanna Gibson"
+      },
       "post_id": 2,
       "body": "THAT. Then again--\"BEFORE SHE HAD THIS FIT--\" you never tasted an egg!' 'I HAVE tasted eggs, certainly,' said Alice, as she spoke. Alice did not like to have it.",
       "created_at": "2012-11-06"
     },
     {
       "id": 10,
+      "author": {
+        "name": "Logan Schowalter"
+      },
       "post_id": 3,
-      "author": "Logan Schowalter",
       "body": "I'd been the whiting,' said the Hatter, it woke up again with a T!' said the Gryphon. '--you advance twice--' 'Each with a growl, And concluded the banquet--] 'What IS the fun?' said.",
       "created_at": "2012-12-07"
     },
     {
       "id": 11,
+      "author": {
+        "name": "Logan Schowalter"
+      },
       "post_id": 1,
-      "author": "Logan Schowalter",
       "body": "I don't want to be?' it asked. 'Oh, I'm not Ada,' she said, 'and see whether it's marked \"poison\" or not'; for she had asked it aloud; and in despair she put her hand on the end of the.",
       "created_at": "2012-08-05"
     }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-exec": "^0.4.6",
-    "grunt-json-server": "git://github.com/fzaninotto/grunt-json-server.git#c834e50e2151a16930f1378324cf96b91438bdae",
+    "grunt-json-server": "git://github.com/fzaninotto/grunt-json-server.git",
     "grunt-karma": "^0.8.3",
     "grunt-mocha-test": "^0.12.7",
     "grunt-ng-annotate": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "npm": "^2.10.0"
   },
   "devDependencies": {
-    "admin-config": "^0.2.4",
+    "admin-config": "marmelab/admin-config#map_transform",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "npm": "^2.10.0"
   },
   "devDependencies": {
-    "admin-config": "marmelab/admin-config#map_transform",
+    "admin-config": "^0.2.5",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -42,7 +42,7 @@ define(function (require) {
                 scope.datastore = scope.datastore();
 
                 scope.getClassesForField = function(field, entry) {
-                    return 'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');
+                    return 'ng-admin-field-' + field.name().replace('.', '_') + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');
                 };
 
                 scope.getInputForField = function(field) {

--- a/src/javascripts/ng-admin/Crud/list/ListController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListController.js
@@ -41,28 +41,24 @@ define(function () {
             return;
         }
 
-        var progression = this.progression,
-            self = this;
+        let view = this.view,
+            datastore = this.datastore;
 
-        progression.start();
+        this.progression.start();
 
         this.ReadQueries
-            .getAll(this.view, page, this.search, this.sortField, this.sortDir)
-            .then(function (response) {
-                progression.done();
-                var references = self.view.getReferences();
+            .getAll(view, page, this.search, this.sortField, this.sortDir)
+            .then(response => {
+                this.progression.done();
+                var references = view.getReferences();
 
-                self.dataStore.mapEntries(
-                    self.entity.name(),
-                    self.view.identifier(),
-                    self.fields,
-                    response.data
-                ).map(function (entry) {
-                    self.dataStore.fillReferencesValuesFromEntry(entry, references, true);
-                    self.dataStore.addEntry(self.entity.uniqueId, entry);
-                });
+                view.mapEntries(response.data)
+                    .map(entry => {
+                        dataStore.fillReferencesValuesFromEntry(entry, references, true);
+                        dataStore.addEntry(this.entity.uniqueId, entry);
+                    });
 
-                self.loadingPage = false;
+                this.loadingPage = false;
             });
     };
 

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -41,6 +41,13 @@ function dataStoreProvider() {
     }];
 }
 
+
+function entryConstructorProvider() {
+    return ['AdminDescription', function (AdminDescription) {
+        return AdminDescription.getEntryConstructor();
+    }];
+}
+
 function routing($stateProvider) {
 
     $stateProvider
@@ -56,6 +63,7 @@ function routing($stateProvider) {
             templateProvider: templateProvider('ListView', listLayoutTemplate),
             resolve: {
                 dataStore: dataStoreProvider(),
+                Entry: entryConstructorProvider(),
                 view: viewProvider('ListView'),
                 filterData: ['ReadQueries', 'view', function (ReadQueries, view) {
                     return ReadQueries.getAllReferencedData(view.getFilterReferences(false));
@@ -65,11 +73,11 @@ function routing($stateProvider) {
                     var filterEntries;
 
                     for (var name in filterData) {
-                        filterEntries = dataStore.mapEntries(
-                            filters[name].targetEntity().name(),
-                            filters[name].targetEntity().identifier(),
+                        filterEntries = Entry.createArrayFromRest(
+                            filterData[name],
                             [filters[name].targetField()],
-                            filterData[name]
+                            filters[name].targetEntity().name(),
+                            filters[name].targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -98,6 +106,7 @@ function routing($stateProvider) {
                     template: listTemplate,
                     resolve: {
                         dataStore: dataStoreProvider(),
+                        Entry: entryConstructorProvider(),
                         view: viewProvider('ListView'),
                         response: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                             var page = $stateParams.page,
@@ -116,17 +125,17 @@ function routing($stateProvider) {
                         optimizedReferencedData: ['ReadQueries', 'view', 'response', function (ReadQueries, view, response) {
                             return ReadQueries.getOptimizedReferencedData(view.getOptimizedReferences(), response.data);
                         }],
-                        referencedEntries: ['dataStore', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, view, nonOptimizedReferencedData, optimizedReferencedData) {
+                        referencedEntries: ['dataStore', 'Entry', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, Entry, view, nonOptimizedReferencedData, optimizedReferencedData) {
                             var references = view.getReferences(),
                                 referencedData = angular.extend(nonOptimizedReferencedData, optimizedReferencedData),
                                 referencedEntries;
 
                             for (var name in referencedData) {
-                                referencedEntries = dataStore.mapEntries(
-                                    references[name].targetEntity().name(),
-                                    references[name].targetEntity().identifier(),
+                                referencedEntries = Entry.createArrayFromRest(
+                                    referencedData[name],
                                     [references[name].targetField()],
-                                    referencedData[name]
+                                    references[name].targetEntity().name(),
+                                    references[name].targetEntity().identifier().name()
                                 );
 
                                 dataStore.setEntries(
@@ -173,6 +182,7 @@ function routing($stateProvider) {
             },
             resolve: {
                 dataStore: dataStoreProvider(),
+                Entry: entryConstructorProvider(),
                 view: viewProvider('ShowView'),
                 rawEntry: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                     return ReadQueries.getOne(view.getEntity(), view.type, $stateParams.id, view.identifier(), view.getUrl());
@@ -186,17 +196,17 @@ function routing($stateProvider) {
                 optimizedReferencedData: ['ReadQueries', 'view', 'entry', function (ReadQueries, view, entry) {
                     return ReadQueries.getOptimizedReferencedData(view.getOptimizedReferences(), [entry.values]);
                 }],
-                referencedEntries: ['dataStore', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, view, nonOptimizedReferencedData, optimizedReferencedData) {
+                referencedEntries: ['dataStore', 'Entry', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, Entry, view, nonOptimizedReferencedData, optimizedReferencedData) {
                     var references = view.getReferences(),
                         referencedData = angular.extend(nonOptimizedReferencedData, optimizedReferencedData),
                         referencedEntries;
 
                     for (var name in referencedData) {
-                        referencedEntries = dataStore.mapEntries(
-                            references[name].targetEntity().name(),
-                            references[name].targetEntity().identifier(),
+                        referencedEntries = Entry.createArrayFromRest(
+                            referencedData[name],
                             [references[name].targetField()],
-                            referencedData[name]
+                            references[name].targetEntity().name(),
+                            references[name].targetEntity().identifier()
                         );
 
                         dataStore.setEntries(
@@ -214,7 +224,7 @@ function routing($stateProvider) {
 
                     return ReadQueries.getReferencedListData(referencedLists, sortField, sortDir, entry.identifierValue);
                 }],
-                referencedListEntries: ['dataStore', 'view', 'referencedListData', function (dataStore, view, referencedListData) {
+                referencedListEntries: ['dataStore', 'Entry', 'view', 'referencedListData', function (dataStore, Entry, view, referencedListData) {
                     var referencedLists = view.getReferencedLists();
                     var referencedList;
                     var referencedListEntries;
@@ -223,11 +233,11 @@ function routing($stateProvider) {
                         referencedList = referencedLists[i];
                         referencedListEntries = referencedListData[i];
 
-                        referencedListEntries = dataStore.mapEntries(
-                            referencedList.targetEntity().name(),
-                            referencedList.targetEntity().identifier(),
+                        referencedListEntries = Entry.createArrayFromRest(
+                            referencedListEntries,
                             referencedList.targetFields(),
-                            referencedListEntries
+                            referencedList.targetEntity().name(),
+                            referencedList.targetEntity().identifier()
                         );
 
                         dataStore.setEntries(
@@ -261,6 +271,7 @@ function routing($stateProvider) {
             resolve: {
                 dataStore: dataStoreProvider(),
                 view: viewProvider('CreateView'),
+                Entry: entryConstructorProvider(),
                 entry: ['dataStore', 'view', function (dataStore, view) {
                     var entry = dataStore.createEntry(view.entity.name(), view.identifier(), view.getFields());
                     dataStore.addEntry(view.getEntity().uniqueId, entry);
@@ -270,16 +281,16 @@ function routing($stateProvider) {
                 choiceData: ['ReadQueries', 'view', function (ReadQueries, view) {
                     return ReadQueries.getAllReferencedData(view.getReferences(false));
                 }],
-                choiceEntries: ['dataStore', 'view', 'choiceData', function (dataStore, view, filterData) {
+                choiceEntries: ['dataStore', 'Entry', 'view', 'choiceData', function (dataStore, Entry, view, filterData) {
                     var choices = view.getReferences(false);
                     var choiceEntries;
 
                     for (var name in filterData) {
-                        choiceEntries = dataStore.mapEntries(
-                            choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier(),
+                        choiceEntries = Entry.createArrayFromRest(
+                            filterData[name],
                             [choices[name].targetField()],
-                            filterData[name]
+                            choices[name].targetEntity().name(),
+                            choices[name].targetEntity().identifier()
                         );
 
                         dataStore.setEntries(
@@ -310,6 +321,7 @@ function routing($stateProvider) {
             },
             resolve: {
                 dataStore: dataStoreProvider(),
+                Entry: entryConstructorProvider(),
                 view: viewProvider('EditView'),
                 rawEntry: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                     return ReadQueries.getOne(view.getEntity(), view.type, $stateParams.id, view.identifier(), view.getUrl());
@@ -323,17 +335,17 @@ function routing($stateProvider) {
                 optimizedReferencedData: ['ReadQueries', 'view', 'entry', function (ReadQueries, view, entry) {
                     return ReadQueries.getOptimizedReferencedData(view.getOptimizedReferences(), [entry.values]);
                 }],
-                referencedEntries: ['dataStore', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, view, nonOptimizedReferencedData, optimizedReferencedData) {
+                referencedEntries: ['dataStore', 'Entry', 'view', 'nonOptimizedReferencedData', 'optimizedReferencedData', function (dataStore, Entry, view, nonOptimizedReferencedData, optimizedReferencedData) {
                     var references = view.getReferences(),
                         referencedData = angular.extend(nonOptimizedReferencedData, optimizedReferencedData),
                         referencedEntries;
 
                     for (var name in referencedData) {
-                        referencedEntries = dataStore.mapEntries(
-                            references[name].targetEntity().name(),
-                            references[name].targetEntity().identifier(),
+                        referencedEntries = Entry.createArrayFromRest(
+                            referencedData[name],
                             [references[name].targetField()],
-                            referencedData[name]
+                            references[name].targetEntity().name(),
+                            references[name].targetEntity().identifier()
                         );
 
                         dataStore.setEntries(
@@ -351,7 +363,7 @@ function routing($stateProvider) {
 
                     return ReadQueries.getReferencedListData(referencedLists, sortField, sortDir, entry.identifierValue);
                 }],
-                referencedListEntries: ['dataStore', 'view', 'referencedListData', function (dataStore, view, referencedListData) {
+                referencedListEntries: ['dataStore', 'Entry', 'view', 'referencedListData', function (dataStore, Entry, view, referencedListData) {
                     var referencedLists = view.getReferencedLists();
                     var referencedList;
                     var referencedListEntries;
@@ -360,11 +372,11 @@ function routing($stateProvider) {
                         referencedList = referencedLists[i];
                         referencedListEntries = referencedListData[i];
 
-                        referencedListEntries = dataStore.mapEntries(
-                            referencedList.targetEntity().name(),
-                            referencedList.targetEntity().identifier(),
+                        referencedListEntries = Entry.createArrayFromRest(
+                            referencedListEntries,
                             referencedList.targetFields(),
-                            referencedListEntries
+                            referencedList.targetEntity().name(),
+                            referencedList.targetEntity().identifier()
                         );
 
                         dataStore.setEntries(
@@ -382,16 +394,16 @@ function routing($stateProvider) {
                 choiceData: ['ReadQueries', 'view', function (ReadQueries, view) {
                     return ReadQueries.getAllReferencedData(view.getReferences(false));
                 }],
-                choiceEntries: ['dataStore', 'view', 'choiceData', function (dataStore, view, filterData) {
+                choiceEntries: ['dataStore', 'Entry', 'view', 'choiceData', function (dataStore, Entry, view, filterData) {
                     var choices = view.getReferences(false);
                     var choiceEntries;
 
                     for (var name in filterData) {
-                        choiceEntries = dataStore.mapEntries(
-                            choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier(),
+                        choiceEntries = Entry.createArrayFromRest(
+                            filterData[name],
                             [choices[name].targetField()],
-                            filterData[name]
+                            choices[name].targetEntity().name(),
+                            choices[name].targetEntity().identifier()
                         );
 
                         dataStore.setEntries(

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -272,8 +272,8 @@ function routing($stateProvider) {
                 dataStore: dataStoreProvider(),
                 view: viewProvider('CreateView'),
                 Entry: entryConstructorProvider(),
-                entry: ['dataStore', 'view', function (dataStore, view) {
-                    var entry = dataStore.createEntry(view.entity.name(), view.identifier(), view.getFields());
+                entry: ['dataStore', 'Entry', 'view', function (dataStore, Entry, view) {
+                    var entry = Entry.createForFields(view.getFields(), view.entity.name());
                     dataStore.addEntry(view.getEntity().uniqueId, entry);
 
                     return entry;

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -206,7 +206,7 @@ function routing($stateProvider) {
                             referencedData[name],
                             [references[name].targetField()],
                             references[name].targetEntity().name(),
-                            references[name].targetEntity().identifier()
+                            references[name].targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -237,7 +237,7 @@ function routing($stateProvider) {
                             referencedListEntries,
                             referencedList.targetFields(),
                             referencedList.targetEntity().name(),
-                            referencedList.targetEntity().identifier()
+                            referencedList.targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -290,7 +290,7 @@ function routing($stateProvider) {
                             filterData[name],
                             [choices[name].targetField()],
                             choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier()
+                            choices[name].targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -345,7 +345,7 @@ function routing($stateProvider) {
                             referencedData[name],
                             [references[name].targetField()],
                             references[name].targetEntity().name(),
-                            references[name].targetEntity().identifier()
+                            references[name].targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -376,7 +376,7 @@ function routing($stateProvider) {
                             referencedListEntries,
                             referencedList.targetFields(),
                             referencedList.targetEntity().name(),
-                            referencedList.targetEntity().identifier()
+                            referencedList.targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(
@@ -403,7 +403,7 @@ function routing($stateProvider) {
                             filterData[name],
                             [choices[name].targetField()],
                             choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier()
+                            choices[name].targetEntity().identifier().name()
                         );
 
                         dataStore.setEntries(

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -138,12 +138,7 @@ function routing($stateProvider) {
                             return true;
                         }],
                         entries: ['dataStore', 'view', 'response', 'referencedEntries', function (dataStore, view, response, referencedEntries) {
-                            var entries = dataStore.mapEntries(
-                                view.entity.name(),
-                                view.identifier(),
-                                view.getFields(),
-                                response.data
-                            );
+                            var entries = view.mapEntries(response.data);
 
                             // shortcut to diplay collection of entry with included referenced values
                             dataStore.fillReferencesValuesFromCollection(entries, view.getReferences(), true);
@@ -182,13 +177,8 @@ function routing($stateProvider) {
                 rawEntry: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                     return ReadQueries.getOne(view.getEntity(), view.type, $stateParams.id, view.identifier(), view.getUrl());
                 }],
-                entry: ['dataStore', 'view', 'rawEntry', function(dataStore, view, rawEntry) {
-                    return dataStore.mapEntry(
-                        view.entity.name(),
-                        view.identifier(),
-                        view.getFields(),
-                        rawEntry
-                    );
+                entry: ['view', 'rawEntry', function(view, rawEntry) {
+                    return view.mapEntry(rawEntry);
                 }],
                 nonOptimizedReferencedData: ['ReadQueries', 'view', 'entry', function (ReadQueries, view, entry) {
                     return ReadQueries.getFilteredReferenceData(view.getNonOptimizedReferences(), [entry.values]);
@@ -324,13 +314,8 @@ function routing($stateProvider) {
                 rawEntry: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                     return ReadQueries.getOne(view.getEntity(), view.type, $stateParams.id, view.identifier(), view.getUrl());
                 }],
-                entry: ['dataStore', 'view', 'rawEntry', function(dataStore, view, rawEntry) {
-                    return dataStore.mapEntry(
-                        view.entity.name(),
-                        view.identifier(),
-                        view.getFields(),
-                        rawEntry
-                    );
+                entry: ['view', 'rawEntry', function(view, rawEntry) {
+                    return view.mapEntry(rawEntry);
                 }],
                 nonOptimizedReferencedData: ['ReadQueries', 'view', 'entry', function (ReadQueries, view, entry) {
                     return ReadQueries.getFilteredReferenceData(view.getNonOptimizedReferences(), [entry.values]);
@@ -442,13 +427,8 @@ function routing($stateProvider) {
                 rawEntry: ['$stateParams', 'ReadQueries', 'view', function ($stateParams, ReadQueries, view) {
                     return ReadQueries.getOne(view.getEntity(), view.type, $stateParams.id, view.identifier(), view.getUrl());
                 }],
-                entry: ['dataStore', 'view', 'rawEntry', function(dataStore, view, rawEntry) {
-                    return dataStore.mapEntry(
-                        view.entity.name(),
-                        view.identifier(),
-                        view.getFields(),
-                        rawEntry
-                    );
+                entry: ['view', 'rawEntry', function(view, rawEntry) {
+                    return view.mapEntry(rawEntry);
                 }],
             }
         });

--- a/src/javascripts/test/e2e/EditionViewSpec.js
+++ b/src/javascripts/test/e2e/EditionViewSpec.js
@@ -1,19 +1,40 @@
 /*global describe,it,expect,$$,element,browser,by*/
-describe('EditionViews', function () {
+describe('EditionView', function () {
     'use strict';
 
-    var hasToLoad = true;
-    beforeEach(function() {
-        if (hasToLoad) {
-            browser.get(browser.baseUrl + '#/posts/edit/1');
-            hasToLoad = false;
-        }
-    });
+    describe('Fields mapping', function() {
+
+        beforeEach(function() {
+            browser.get(browser.baseUrl + '#/comments/edit/11');
+        });
+
+        it('should map nested fields from the REST response', function () {
+            $$('.ng-admin-field-author_name input').then(function (inputs) {
+                expect(inputs.length).toBe(1);
+                expect(inputs[0].getAttribute('value')).toBe('Logan Schowalter');
+            });
+        });
+    })
 
     describe('ChoiceField', function() {
+
+        beforeEach(function() {
+            browser.get(browser.baseUrl + '#/posts/edit/1');
+        });
+
         it('should render correctly choice fields', function () {
-            $$('.ng-admin-field-category .ui-select-container').then(function (uiSelect) {
-                expect(uiSelect.length).toBe(1);
+            $$('.ng-admin-field-category .ui-select-container')
+            .then(function(uiSelect) {
+                expect(uiSelect.length).toBe(1)
+            })
+            .then(function() {
+                return $$('.ng-admin-field-category .btn').first().click();
+            })
+            .then(function() {
+                return $$('.ng-admin-field-category .ui-select-choices-row');
+            })
+            .then(function(choices) {
+                expect(choices.length).toBe(2)
             });
         });
     });

--- a/src/javascripts/test/e2e/EditionViewSpec.js
+++ b/src/javascripts/test/e2e/EditionViewSpec.js
@@ -9,9 +9,37 @@ describe('EditionView', function () {
         });
 
         it('should map nested fields from the REST response', function () {
-            $$('.ng-admin-field-author_name input').then(function (inputs) {
+            $$('.ng-admin-field-author_name input')
+            .then(function (inputs) {
                 expect(inputs.length).toBe(1);
                 expect(inputs[0].getAttribute('value')).toBe('Logan Schowalter');
+                return inputs[0];
+            })
+            .then(function(input) {
+                return input.sendKeys('r');
+            })
+            .then(function() {
+                return $$('button[type="submit"]').first().click();
+            })
+            .then(function() {
+                return browser.get(browser.baseUrl + '#/comments/list');     
+            })
+            .then(function() {
+                return browser.get(browser.baseUrl + '#/comments/edit/11');
+            })
+            .then(function() {
+                return $$('.ng-admin-field-author_name input').first();
+            })
+            .then(function (input) {
+                expect(input.getAttribute('value')).toBe('Logan Schowalterr');
+                // the data was modified in the server, we need to change it back to its original value
+                return input;
+            })
+            .then(function(input) {
+                return input.sendKeys("\b");
+            })
+            .then(function() {
+                return $$('button[type="submit"]').first().click();
             });
         });
     })

--- a/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
+++ b/src/javascripts/test/unit/Main/component/service/config/view/ListViewSpec.js
@@ -28,7 +28,7 @@ describe("Service: ListView config", function () {
                     return value.substr(0, 5) + '...';
                 }));
 
-            var entries = dataStore.mapEntries(list.entity.name(), list.identifier(), list.getFields(), [
+            var entries = list.mapEntries([
                 { id: 1, human_id: 1, name: 'Suna'},
                 { id: 2, human_id: 2, name: 'Boby'},
                 { id: 3, human_id: 1, name: 'Mizute'}


### PR DESCRIPTION
Currently, callbacks registered on fields with `map()` are applied to the REST response to turn it into an Entry (when fetching results) AND to the entries to turn them into a response (when pushing modifications). It doesn't make sense, and prevents some new features, such as deeply nested fields (refs. #525).

This PR fixes that. Now you can do things like:

```js
listView.fields([
    nga.field('title'),
    nga.field('author.name')
]);
```

to map REST responses looking like:

```json
[
  {
    "title": "War and Peace",
    "author": {
      "name": "Leo Tolstoi"
    }
  },
  {
    "title": "Anna Karenina",
    "author": {
      "name": "Leo Tolstoi"
    }
  }
]
```

Depends on https://github.com/marmelab/admin-config/pull/20