### PR TITLE
[RFR] isDetailView doesn't work on refernced_list entity id-field

### DIFF
--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -132,6 +132,7 @@
                     .targetEntity(comment)
                     .targetReferenceField('post_id')
                     .targetFields([
+                        nga.field('id').isDetailLink(true),
                         nga.field('created_at').label('Posted'),
                         nga.field('body').label('Comment')
                     ])

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -43,10 +43,10 @@ define(function (require) {
                         route = 'show';
                     }
                     $state.go($state.get(route),
-                    angular.extend({
+                    angular.extend({}, $state.params, {
                         entity: scope.entry.entityName,
                         id: scope.entry.identifierValue
-                    }, $state.params));
+                    }));
                 };
                 scope.gotoReference = function () {
                     var referenceEntity = scope.field.targetEntity().name();

--- a/src/javascripts/test/e2e/EditionViewSpec.js
+++ b/src/javascripts/test/e2e/EditionViewSpec.js
@@ -66,4 +66,17 @@ describe('EditionView', function () {
             });
         });
     });
+
+    describe('DetailLink', function() {
+        beforeEach(function() {
+            browser.baseUrl + '#/posts/edit/1';
+        });
+
+        it('should redirect to corresponding detail view even for referenced_list entity', function () {
+            $$('#row-comments td a').first().click();
+            browser.getLocationAbsUrl().then(function(url){
+                expect(url).toContain('/comments/edit/');
+            });
+        });
+    });
 });

--- a/src/javascripts/test/e2e/ShowViewSpec.js
+++ b/src/javascripts/test/e2e/ShowViewSpec.js
@@ -26,10 +26,11 @@ describe('ShowView', function () {
     describe('ReferencedListField', function() {
         it('should render as a datagrid', function () {
             $$('.ng-admin-field-comments th').then(function (inputs) {
-                expect(inputs.length).toBe(2);
+                expect(inputs.length).toBe(3);
 
-                expect(inputs[0].getAttribute('class')).toBe('ng-scope ng-admin-column-created_at');
-                expect(inputs[1].getAttribute('class')).toBe('ng-scope ng-admin-column-body');
+                expect(inputs[0].getAttribute('class')).toBe('ng-scope ng-admin-column-id');
+                expect(inputs[1].getAttribute('class')).toBe('ng-scope ng-admin-column-created_at');
+                expect(inputs[2].getAttribute('class')).toBe('ng-scope ng-admin-column-body');
             });
         });
     });


### PR DESCRIPTION
This PR is absolutely analogous to https://github.com/marmelab/ng-admin/pull/537
This time isDetailLink() applied to `referenced_list` entity doesn't work because of state parameter override.
I've created a e2e-test to demonstrate it. Test fails on your master branch, and passes on my commit.