### PR TITLE
[RFR] Do not deduplicate single choice remote complete fields

### DIFF
--- a/src/javascripts/ng-admin/Crud/repository/ReferenceRefresher.js
+++ b/src/javascripts/ng-admin/Crud/repository/ReferenceRefresher.js
@@ -7,10 +7,15 @@ class ReferenceRefresher {
         var referenceFields = {};
         referenceFields[field.name()] = field;
 
-        return this.ReadQueries.getAllReferencedData(referenceFields, search)
+        var promise = this.ReadQueries.getAllReferencedData(referenceFields, search)
             .then(r => r[field.name()])
-            .then(results => this._transformRecords(field, results))
-            .then(formattedResults => this._removeDuplicates(formattedResults, currentValue));
+            .then(results => this._transformRecords(field, results));
+
+        if (field.type() === 'reference_many' || field.type() === 'choices') {
+            promise = promise.then(formattedResults => this._removeDuplicates(formattedResults, currentValue));
+        }
+
+        return promise;
     }
 
     getInitialChoices(field, values) {

--- a/src/javascripts/test/unit/Crud/repository/ReferenceRefresherSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/ReferenceRefresherSpec.js
@@ -22,7 +22,8 @@ describe('ReferenceRefresher', function() {
             targetField: ()  => {
                 return { name: () => 'title' }
             },
-            getMappedValue: v => v
+            getMappedValue: v => v,
+            type: () => 'reference'
         };
     });
 
@@ -61,23 +62,43 @@ describe('ReferenceRefresher', function() {
             });
         });
 
-        it('should remove already selected values from result list (to fix some UI-Select duplicated options)', function(done) {
-            var readQueries = new ReadQueries();
-            sinon.stub(readQueries, 'getAllReferencedData', function() {
-                return mixins.buildPromise({
-                    post: [
-                        { id: 1, title: 'Discover some awesome stuff' },
-                        { id: 2, title: 'Another great post'}
-                    ]
+        describe('Choice deduplication (to fix some UI-Select duplicated options)', function() {
+            var refresher;
+            beforeEach(function() {
+                var readQueries = new ReadQueries();
+                sinon.stub(readQueries, 'getAllReferencedData', function() {
+                    return mixins.buildPromise({
+                        post: [
+                            { id: 1, title: 'Discover some awesome stuff' },
+                            { id: 2, title: 'Another great post'}
+                        ]
+                    });
+                });
+
+                refresher = new ReferenceRefresher(readQueries);
+            });
+
+            it('should remove already selected values from result list in case of multiple choices component', function(done) {
+                fakeField.type = () => 'reference_many';
+
+                refresher.refresh(fakeField, [1], 'foo').then(function(results) {
+                    expect(results).toEqual([
+                        { value: 2, label: 'Another great post' }
+                    ]);
+                    done();
                 });
             });
 
-            var refresher = new ReferenceRefresher(readQueries);
-            refresher.refresh(fakeField, [1], 'foo').then(function(results) {
-                expect(results).toEqual([
-                    { value: 2, label: 'Another great post' }
-                ]);
-                done();
+            it('should not de-duplicate simple choice in case of single choice component', function(done) {
+                fakeField.type = () => 'reference';
+
+                refresher.refresh(fakeField, [1], 'foo').then(function(results) {
+                    expect(results).toEqual([
+                        { value: 1, label: 'Discover some awesome stuff' },
+                        { value: 2, label: 'Another great post' }
+                    ]);
+                    done();
+                });
             });
         });
 


### PR DESCRIPTION
Fixing an issue found while debugging with @manuelnaranjo on [Gitter].

To prevent duplicates in multiple choices field, we remove already selected values from API responses. It works well for `reference_many` fields, but not for `reference` one. This PR disable deduplication for single choice fields.