### PR TITLE
Imprve Reference Field View Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": "^2.10.0"
   },
   "devDependencies": {
-    "admin-config": "^0.2.5",
+    "admin-config": "manuelnaranjo/admin-config#reference-field-target-entries",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget: function () {
-        return '<ma-string-column value="::entry.listValues[field.name()]"></ma-string-column>';
+        return '<ma-column field="::field.targetField()" entry="::field.getEntry(entry.values[field.name()])" entity="::field.targetEntity()" datastore="::datastore()"></ma-column>';
     },
     getLinkWidget: function () {
         return '<a ng-click="gotoReference()">' + this.getReadWidget() + '</a>';


### PR DESCRIPTION
    Reference field should use ma-column instead of ma-string-column so the
    formatting requested by the programmer is honored.
