### PR TITLE
[RFR] Expose field constructors to avoid Webpack/Babel fuss

### DIFF
--- a/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
+++ b/src/javascripts/ng-admin/Main/component/provider/NgAdminConfiguration.js
@@ -37,6 +37,10 @@ NgAdminConfiguration.prototype.registerFieldType = function(name, type) {
     return this.adminDescription.registerFieldType(name, type);
 };
 
+NgAdminConfiguration.prototype.getFieldConstructor = function(name) {
+  return this.adminDescription.getFieldConstructor(name);
+};
+
 NgAdminConfiguration.prototype.menu = function(entity) {
     return this.adminDescription.menu(entity);
 };


### PR DESCRIPTION
It becomes possible to recuperate a field constructor without installing the `admin-config` module:

```
var NumberField = nga.getFieldConstructor('number');

// now create a new class extending NumberField
function AmountField(name) {
  NumberField.call(this, name)
}
AmountField.prototype = new NumberField();
AmountField.prototype.constructor = AmountField;
// or something like that
```