### PR TITLE
Grid form

### DIFF
--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -12,7 +12,7 @@ define(function (require) {
             }).join('');
         var template =
 '<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">' +
-    '<label for="{{ field.name() }}" class="col-sm-2 control-label">' +
+    '<label for="{{ field.name() }}" ng-class="field.labelCssClasses()">' +
         '{{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;' +
     '</label>' +
     '<div ng-if="field.editable()" ng-class="getClassesForField(field, entry)" ng-switch="field.type()">' +

--- a/src/javascripts/ng-admin/Crud/form/create.html
+++ b/src/javascripts/ng-admin/Crud/form/create.html
@@ -15,8 +15,21 @@
 
 <div class="row" id="create-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitCreation($event)">
-        <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+        <div ng-repeat="field in ::formController.fields track by $index"
+             ng-class="(field.type()==='fieldset')?'grid-form':''">
+            <div class="form-field form-group" ng-if="field.type()!=='fieldset' && field.type()!=='row'">
+                <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+            </div>
+            <fieldset ng-if="field.type()==='fieldset'">
+                <legend>{{::field.label()}}</legend>
+                <div ng-repeat="row in ::field.rows()"
+                     ng-attr-data-row-span="{{::row.span()}}">
+                    <div ng-repeat="rowField in ::row.fields()"
+                         ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
+                        <ma-field field="::rowField" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+                    </div>
+                </div>
+            </fieldset>
         </div>
 
         <div class="form-group">

--- a/src/javascripts/ng-admin/Crud/form/create.html
+++ b/src/javascripts/ng-admin/Crud/form/create.html
@@ -15,17 +15,19 @@
 
 <div class="row" id="create-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitCreation($event)">
-        <div ng-repeat="field in ::formController.fields track by $index"
-             ng-class="(field.type()==='fieldset')?'grid-form':''">
-            <div class="form-field form-group" ng-if="field.type()!=='fieldset' && field.type()!=='row'">
+        <div ng-repeat="field in ::formController.fields track by $index">
+
+            <div class="form-field form-group" ng-if="!field.isFieldset()">
                 <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
             </div>
-            <fieldset ng-if="field.type()==='fieldset'">
+
+            <fieldset ng-if="field.isFieldset()">
                 <legend>{{::field.label()}}</legend>
                 <div ng-repeat="row in ::field.rows()"
-                     ng-attr-data-row-span="{{::row.span()}}">
+                     class="row-fluid" ng-class="::row.getClasses()">
                     <div ng-repeat="rowField in ::row.fields()"
-                         ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
+                         class="form-group"
+                         ng-class="::row.editCssSpanClass(rowField)">
                         <ma-field field="::rowField" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
                     </div>
                 </div>

--- a/src/javascripts/ng-admin/Crud/form/edit.html
+++ b/src/javascripts/ng-admin/Crud/form/edit.html
@@ -16,10 +16,22 @@
 
 <div class="row" id="edit-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitEdition($event)">
-        <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+        <div ng-repeat="field in ::formController.fields track by $index"
+             ng-class="(field.type()==='fieldset')?'grid-form':''">
+            <div class="form-field form-group" ng-if="field.type()!=='fieldset' && field.type()!=='row'">
+                <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+            </div>
+            <fieldset ng-if="field.type()==='fieldset'">
+                <legend>{{::field.label()}}</legend>
+                <div ng-repeat="row in ::field.rows()"
+                     ng-attr-data-row-span="{{::row.span()}}">
+                    <div ng-repeat="rowField in ::row.fields()"
+                         ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
+                        <ma-field field="::rowField" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+                    </div>
+                </div>
+            </fieldset>
         </div>
-
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-ok"></span> Save Changes</button>

--- a/src/javascripts/ng-admin/Crud/form/edit.html
+++ b/src/javascripts/ng-admin/Crud/form/edit.html
@@ -16,17 +16,19 @@
 
 <div class="row" id="edit-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitEdition($event)">
-        <div ng-repeat="field in ::formController.fields track by $index"
-             ng-class="(field.type()==='fieldset')?'grid-form':''">
-            <div class="form-field form-group" ng-if="field.type()!=='fieldset' && field.type()!=='row'">
+        <div ng-repeat="field in ::formController.fields track by $index">
+
+            <div class="form-field form-group" ng-if="!field.isFieldset()">
                 <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
             </div>
-            <fieldset ng-if="field.type()==='fieldset'">
+
+            <fieldset ng-if="field.isFieldset()">
                 <legend>{{::field.label()}}</legend>
                 <div ng-repeat="row in ::field.rows()"
-                     ng-attr-data-row-span="{{::row.span()}}">
+                     class="row-fluid" ng-class="::row.getClasses()">
                     <div ng-repeat="rowField in ::row.fields()"
-                         ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
+                         class="form-group"
+                         ng-class="::row.editCssSpanClass(rowField)">
                         <ma-field field="::rowField" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
                     </div>
                 </div>

--- a/src/javascripts/ng-admin/Crud/show/show.html
+++ b/src/javascripts/ng-admin/Crud/show/show.html
@@ -18,26 +18,32 @@
 
 <div class="row form-horizontal" id="show-view">
     <div ng-repeat="field in ::showController.fields track by $index"
-         class="col-lg-12"
-         ng-class="(field.type()==='fieldset')?'grid-form':'form-group'">
+         class="col-lg-12 form-group">
 
         <!-- non fieldset -->
-        <label class="col-sm-2 control-label" ng-if="field.type()!=='fieldset'">{{ field.label() }}</label>
+        <label class="col-sm-2 control-label" ng-if="!field.isFieldset()">{{ field.label() }}</label>
 
-        <div ng-if="field.type()!=='fieldset'" class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
+        <div ng-if="!field.isFieldset()" class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
 
             <ma-column field="::field" entry="::entry" entity="::entity" datastore="::showController.dataStore"></ma-column>
 
         </div>
 
-        <fieldset ng-if="field.type()==='fieldset'">
+        <fieldset ng-if="field.isFieldset()">
             <legend>{{::field.label()}}</legend>
             <div ng-repeat="row in ::field.rows()"
-                 ng-attr-data-row-span="{{::row.span()}}">
+                 class="row-fluid"
+                 ng-class="row.getClasses()">
                 <div ng-repeat="rowField in ::row.fields()"
-                     ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
-                    <label>{{ rowField.label() }}</label>
-                    <ma-column field="::rowField" entry="::entry" entity="::entity" datastore="::showController.dataStore"></ma-column>
+                     class="form-group"
+                     ng-class="::row.cssSpanClass(rowField)">
+                    <label for="::{{ rowField.name() }}">{{ rowField.label() }}</label>
+                    <div class="form-control">
+                        <ma-column field="::rowField" entry="::entry"
+                                   entity="::entity"
+                                   datastore="::showController.dataStore">
+                        </ma-column>
+                    </div>
                 </div>
             </div>
 

--- a/src/javascripts/ng-admin/Crud/show/show.html
+++ b/src/javascripts/ng-admin/Crud/show/show.html
@@ -17,16 +17,31 @@
 
 
 <div class="row form-horizontal" id="show-view">
+    <div ng-repeat="field in ::showController.fields track by $index"
+         class="col-lg-12"
+         ng-class="(field.type()==='fieldset')?'grid-form':'form-group'">
 
-    <div class="col-lg-12 form-group" ng-repeat="field in ::showController.fields track by $index">
+        <!-- non fieldset -->
+        <label class="col-sm-2 control-label" ng-if="field.type()!=='fieldset'">{{ field.label() }}</label>
 
-        <label class="col-sm-2 control-label">{{ field.label() }}</label>
-
-        <div class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
+        <div ng-if="field.type()!=='fieldset'" class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
 
             <ma-column field="::field" entry="::entry" entity="::entity" datastore="::showController.dataStore"></ma-column>
 
         </div>
+
+        <fieldset ng-if="field.type()==='fieldset'">
+            <legend>{{::field.label()}}</legend>
+            <div ng-repeat="row in ::field.rows()"
+                 ng-attr-data-row-span="{{::row.span()}}">
+                <div ng-repeat="rowField in ::row.fields()"
+                     ng-attr-data-field-span="{{::rowField.attributes().fieldSpan || 1}}">
+                    <label>{{ rowField.label() }}</label>
+                    <ma-column field="::rowField" entry="::entry" entity="::entity" datastore="::showController.dataStore"></ma-column>
+                </div>
+            </div>
+
+        </fieldset>
     </div>
 
 </div>

--- a/src/sass/ng-admin.scss
+++ b/src/sass/ng-admin.scss
@@ -41,8 +41,8 @@ ul.collapsible {
 }
 
 /**
-* Dashboard
-*/
+ * Dashboard
+ */
 .dashboard-starter {
     margin-bottom: 30px;
 }
@@ -93,8 +93,8 @@ ul.collapsible {
 }
 
 /**
-* Grid
-*/
+ * Grid
+ */
 
 #page-wrapper .page-header {
     margin: 10px 0 15px;
@@ -125,7 +125,7 @@ ma-view-actions {
             }
 
             .btn-default {
-              height: 34px;
+                height: 34px;
             }
         }
 
@@ -198,8 +198,8 @@ div.bottom-loader {
 }
 
 /**
-* Edition form
-*/
+ * Edition form
+ */
 .form-horizontal {
 
     .has-feedback .form-control.ui-select-toggle {
@@ -266,5 +266,68 @@ div.bottom-loader {
     .CodeMirror {
         border: 1px solid #CCC;
         border-radius: 4px;
+    }
+}
+
+&#show-view, {
+    fieldset {
+        .row-fluid {
+            .form-group {
+                .form-control {
+                    border: initial;
+                    border-radius: initial;
+                    box-shadow: initial;
+                    padding: initial;
+                }
+            }
+        }
+    }
+}
+&#show-view, &#create-view, &#edit-view {
+    fieldset {
+        padding-bottom: 5px;
+
+        legend {
+            border: none;
+            border-bottom: 4px solid #404040;
+            color: #404040;
+            font-size: 18px;
+            font-weight: bold;
+            padding-bottom: 5px;
+            position: static;
+            width: 100%;
+            margin-bottom: 0px;
+        }
+
+        .row-fluid {
+            .form-group {
+                margin-left: initial;
+                margin-right: initial;
+                margin-bottom: initial;
+
+                padding: 8px;
+            }
+
+            ma-date-field.col-sm-4 {
+                width: 100%; // force width;
+                button {
+                    padding-bottom: 7px; // fix alignment
+                }
+            }
+        }
+
+        @media only screen and (min-width: 700px) {
+            .row-fluid {
+                .form-group {
+                    border: initial;
+                    border-right: 1px solid #333333;
+                    border-bottom: 1px solid #333333;
+                }
+
+                .form-group:last-child {
+                    border-right: initial;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This series of patches adds support for multiple fields in a row as suggested by #448 

It's using bootstrap for generating the needed layout.

A configuration example would be:

       var datosPersonales = nga.field('Datos Personales', 'fieldset').
        rows([
          // apellido y nombre
          nga.field(null, 'row')
            .fields([
              nga.field('apellido').attributes({span: 3}),
              nga.field('nombre').attributes({span: 3}),
              nga.field('grupo').attributes({span: 3}),
              nga.field('ficha').attributes({span: 2}),
              nga.field('activo').attributes({span: 1})
            ]),

          // datos de la escuela
          nga.field(null, 'row')
            .fields([
             ....
            ]),
          .....
      ])
