### PR TITLE
[RFR] Document the way to define nested entity urls for relationships

### DIFF
--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -4,16 +4,8 @@
 
     var app = angular.module('myApp', ['ng-admin']);
 
-    app.config(['NgAdminConfigurationProvider', 'RestangularProvider', function (NgAdminConfigurationProvider, RestangularProvider) {
-        var nga = NgAdminConfigurationProvider;
-
-        function truncate(value) {
-            if (!value) {
-                return '';
-            }
-
-            return value.length > 50 ? value.substr(0, 50) + '...' : value;
-        }
+    // API Mapping
+    app.config(['RestangularProvider', function (RestangularProvider) {
 
         // use the custom query parameters function to format the API request correctly
         RestangularProvider.addFullRequestInterceptor(function(element, operation, what, url, headers, params) {
@@ -51,6 +43,19 @@
 
             return data;
         });
+    }]);
+
+    // Admin definition
+    app.config(['NgAdminConfigurationProvider', function (NgAdminConfigurationProvider) {
+        var nga = NgAdminConfigurationProvider;
+
+        function truncate(value) {
+            if (!value) {
+                return '';
+            }
+
+            return value.length > 50 ? value.substr(0, 50) + '...' : value;
+        }
 
         var admin = nga.application('ng-admin backend demo') // application main title
             .debug(false) // debug disabled


### PR DESCRIPTION
By default, ng-admin uses filters to fetch entities related to another one. For instance, to fetch all the `comments` related to the `post` entity #123, ng-admin calls the following url:

```
http://[baseApiUrl]/comments?filters={"post_id":123}
```

Some API servers only support a special type of URL for that case:

```
http://[baseApiUrl]/posts/123/comments
```

Restangular doesn't allow to modify the URL of an outgoing request (see [Restangular issue #603](https://github.com/mgonto/restangular/issues/603)), so in order to achieve that you must use an interceptor on the `$http` Angular service.

```js
myApp.config(['$httpProvider', function($httpProvider) {
    $httpProvider.interceptors.push(function() {
        return {
            request: function(config) {
                // test for /comments?filters={post_id:XXX}
                if (/\/comments$/.test(config.url) && config.params.filter && config.params.filter.post_id) {
                    config.url = config.url.replace('comments', 'posts/' + config.params.filter.post_id + '/comments');
                    delete config.params.filter.post_id;
                }
                return config;
            },
        };
    });
}]);
```