### PR TITLE
[RFR] All fields have template

### DIFF
--- a/UPGRADE-0.9.md
+++ b/UPGRADE-0.9.md
@@ -16,4 +16,11 @@ listview.fields([
 
 This removes the need for [custom types](doc/Custom-types.md) in a vast majority of cases.
 
-The `template` field type is deprecated and will be removed in future versions.
+The `template` *field type* is deprecated and will be removed in future versions. Simply use the default field type together with the `template()` method instead:
+
+```js
+// before
+nga.field('name', 'template').template('{{ entry.values.name }}')
+// now
+nga.field('name').template('{{ entry.values.name }}')
+```

--- a/UPGRADE-0.9.md
+++ b/UPGRADE-0.9.md
@@ -2,7 +2,7 @@
 
 ## All fields have `.template()`
 
-All field types now support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+All field types now support the `template()` method, which makes it easy to customize the look and feel of a particular field, without sacrificing the native features.
 
 For instance, if you want to customize the appearance of a `NumberField` according to its value:
 

--- a/UPGRADE-0.9.md
+++ b/UPGRADE-0.9.md
@@ -1,0 +1,19 @@
+# Upgrade to 0.9
+
+## All fields have `.template()`
+
+All field types now support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+
+For instance, if you want to customize the appearance of a `NumberField` according to its value:
+
+```js
+listview.fields([
+    nga.field('amount', 'number')
+        .format('$0,000.00')
+        .template('<span ng-class="{ \'red\': value < 0 }"><ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column></span>')
+]);
+```
+
+This removes the need for [custom types](doc/Custom-types.md) in a vast majority of cases.
+
+The `template` field type is deprecated and will be removed in future versions.

--- a/doc/Configuration-reference.md
+++ b/doc/Configuration-reference.md
@@ -467,7 +467,7 @@ A list of CSS classes to be added to the corresponding field. If you provide a f
             });
 
 * `template(String|Function)`
-All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, without sacrificing the native features.
 
     For instance, if you want to customize the appearance of a `NumberField` according to its value:
 

--- a/doc/Configuration-reference.md
+++ b/doc/Configuration-reference.md
@@ -48,6 +48,7 @@ application
            |-transform
            |-attributes
            |-cssClasses
+           |-template
            |-validation
            |-editable
 ```
@@ -283,10 +284,10 @@ Add filters to the list. Each field maps a property in the API endpoint result.
             nga.field('q').label('Search').pinned(true)
         ]);
 
-    Filter fields can be of any type, including `reference` and `template`. This allows to define custom filters with ease.
+    Filter fields can be of any type, including `reference`. This allows to define custom filters with ease.
 
         listView.filters([
-            nga.field('q', 'template').label('')
+            nga.field('q').label('')
                 .template('<div class="input-group"><input type="text" ng-model="value" placeholder="Search" class="form-control"></input><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span></div>'),
         ]);
 
@@ -379,12 +380,11 @@ A field is the representation of a property of an entity.
 * [`reference` Field Type](#reference-field-type)
 * [`referenced_list` Field Type](#referenced_list-field-type)
 * [`reference_many` Field Type](#reference_many-field-type)
-* [`template` Field Type](#template-field-type)
 
 ### General Field Settings
 
 * `nga.field(name, type)`
-Create a new field of the given type. Default type is 'string', so you can omit it. Bundled types include `string`, `text`, `wysiwyg`, `password`, `email`, `date`, `datetime`, `number`, `float`, `boolean`, `choice`, `choices`, `json`, `file`, `reference`, `reference_list`, `reference_many`, and `template`.
+Create a new field of the given type. Default type is 'string', so you can omit it. Bundled types include `string`, `text`, `wysiwyg`, `password`, `email`, `date`, `datetime`, `number`, `float`, `boolean`, `choice`, `choices`, `json`, `file`, `reference`, `reference_list`, and `reference_many`.
 
 * `label(string label)`
 Define the label of the field. Defaults to the uppercased field name.
@@ -465,6 +465,25 @@ A list of CSS classes to be added to the corresponding field. If you provide a f
 
                 return 'my-custom-css-class-for-list-header';
             });
+
+* `template(String|Function)`
+All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+
+    For instance, if you want to customize the appearance of a `NumberField` according to its value:
+
+        listview.fields([
+            nga.field('amount', 'number')
+                .format('$0,000.00')
+                .template('<span ng-class="{ \'red\': value < 0 }"><ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column></span>')
+        ]);
+
+    The template scope exposes the following variables:
+
+    - `value`, `field`, `entry`, `entity`, and `datastore` in `listView` and `showView`
+    - `value`, `field`, `values`, and `datastore` in filters
+    - `value`, `field`, `entry`, `entity`, `form`, and `datastore` in `editionView` and `creationView`
+
+    Most of the time, `template()` is used to customize the existing ng-admin directives (like `ma-number-column>` in the previous example), for instance by decorating them. If you want to learn about these native directives, explore the [column](../src/javascripts/ng-admin/crud/column), [field](../src/javascripts/ng-admin/crud/field), and [fieldView](../src/javascripts/ng-admin/crud/fieldView) directories in ng-admin source.
 
 * `defaultValue(*)`
 Define the default value of the field in the creation form.
@@ -765,8 +784,3 @@ If set to false, all references (in the limit of `perPage` parameter) would be r
                 })
                 .perPage(10) // limit the number of results to 10
         ]);
-
-### `template` Field Type
-
-* `template(*)`
-Define the template to be displayed for fields of type `template` (can be a string or a function).

--- a/doc/Custom-pages.md
+++ b/doc/Custom-pages.md
@@ -72,12 +72,12 @@ myApp.directive('sendEmail', ['$location', function ($location) {
 
 ## Including the Custom Directive in a Template Field
 
-Now the new directive is ready to be used inside a ng-admin field of type 'template':
+Now the new directive is ready to be used inside a ng-admin field using 'template()':
 
 ```js
 post.showView().fields([
     // ...
-    nga.field('custom_action', 'template')
+    nga.field('custom_action')
         .label('')
         .template('<send-email post="entry"></send-email>')
 ]);

--- a/doc/Getting-started.md
+++ b/doc/Getting-started.md
@@ -504,10 +504,10 @@ Browse to the posts list, and you will see the full-text filter displayed on the
 
 The full-text search isn't looking very good. Usually, a full-text filter widget has no label, a placeholder simply saying "Search", and a magnifying glass icon. How can you turn the current full-text input into that UI?
 
-Fortunately, ng-admin fields can benefit from the power of Angular.Js directives. Using the 'template' field type, you can specify the HTML template to use for rendering the field. And you can use any directive already registered in that HTML. Update the `nga.field('q')` definition as follows:
+Fortunately, ng-admin fields can benefit from the power of Angular.js directives. Using the `template()` field method, you can specify the HTML template to use for rendering the field. And you can use any directive already registered in that HTML. Update the `nga.field('q')` definition as follows:
 
 ```js
-        nga.field('q', 'template')
+        nga.field('q')
             .label('')
             .pinned(true)
             .template('<div class="input-group"><input type="text" ng-model="value" placeholder="Search" class="form-control"></input><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span></div>'),
@@ -653,7 +653,7 @@ myApp.config(['NgAdminConfigurationProvider', function (nga) {
         .listActions(['show'])
         .batchActions([])
         .filters([
-            nga.field('q', 'template')
+            nga.field('q')
                 .label('')
                 .pinned(true)
                 .template('<div class="input-group"><input type="text" ng-model="value" placeholder="Search" class="form-control"></input><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span></div>'),

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -32,9 +32,31 @@ myEntity.listView().fields([
 ]);
 ```
 
+## Customizing The Template For A Given Field
+
+All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+
+For instance, if you want to customize the appearance of a `NumberField` according to its value:
+
+```js
+listview.fields([
+    nga.field('amount', 'number')
+        .format('$0,000.00')
+        .template('<span ng-class="{ \'red\': value < 0 }"><ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column></span>')
+]);
+```
+
+The template scope exposes the following variables:
+
+* `value`, `field`, `entry`, `entity`, and `datastore` in `listView` and `showView`
+* `value`, `field`, `values`, and `datastore` in filters
+* `value`, `field`, `entry`, `entity`, `form`, and `datastore` in `editionView` and `creationView`
+
+Most of the time, `template()` is used to customize the existing ng-admin directives (like `ma-number-column>` in the previous example), for instance by decorating them. If you want to learn about these native directives, explore the [column](../src/javascripts/ng-admin/crud/column), [field](../src/javascripts/ng-admin/crud/field), and [fieldView](../src/javascripts/ng-admin/crud/fieldView) directories in ng-admin source.
+
 ## Customizing Directives Templates
 
-Using Angular's [`$provide`](https://docs.angularjs.org/api/auto/service/$provide) service, and the ability to decorate another provider, you can customize the templates of all the directives used by ng-admin. Here is an example of customization of the 'text' input field customization:
+Using Angular's [`$provide`](https://docs.angularjs.org/api/auto/service/$provide) service, and the ability to decorate another provider, you can customize the template of any directive used by ng-admin for your entire application. Here is an example of customization of the 'text' input field:
 
 ```js
 var myApp = angular.module('myApp', ['ng-admin']);

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -34,7 +34,7 @@ myEntity.listView().fields([
 
 ## Customizing The Template For A Given Field
 
-All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, withut sacrificing the native features.
+All field types support the `template()` method, which makes it easy to customize the look and feel of a particular field, without sacrificing the native features.
 
 For instance, if you want to customize the appearance of a `NumberField` according to its value:
 

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -163,7 +163,7 @@
                     .sortField('created_at')
                     .sortDir('DESC')
                     .listActions(['edit']),
-                nga.field('', 'template').label('')
+                nga.field('').label('')
                     .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm"></ma-filtered-list-button><ma-create-button entity-name="comments" size="sm" label="Create related comment" default-values="{ post_id: entry.values.id }"></ma-create-button></span>')
             ]);
 
@@ -171,8 +171,7 @@
             .fields([
                 nga.field('id'),
                 post.editionView().fields(), // reuse fields from another view in another order
-                nga.field('custom_action', 'template')
-                    .label('')
+                nga.field('custom_action').label('')
                     .template('<send-email post="entry"></send-email>')
             ]);
 
@@ -197,7 +196,7 @@
                     .singleApiCall(ids => { return {'id': ids }})
             ])
             .filters([
-                nga.field('q', 'template')
+                nga.field('q')
                     .label('')
                     .pinned(true)
                     .template('<div class="input-group"><input type="text" ng-model="value" placeholder="Search" class="form-control"></input><span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span></div>'),
@@ -238,9 +237,9 @@
 
         comment.editionView()
             .fields(comment.creationView().fields())
-            .fields([nga.field(null, 'template')
-                .label('')
-                .template('<post-link entry="entry"></post-link>') // template() can take a function or a string
+            .fields([
+                nga.field('').label('')
+                    .template('<post-link entry="entry"></post-link>') // template() can take a function or a string
             ]);
 
         comment.deletionView()
@@ -260,13 +259,13 @@
                         return 'bg-warning text-center';
                     }
                 }),
-                nga.field('custom', 'template')
+                nga.field('custom')
                     .label('Upper name')
                     .template('{{ entry.values.name.toUpperCase() }}')
                     .cssClasses('hidden-xs')
             ])
             .filters([
-                nga.field('published', 'template')
+                nga.field('published')
                     .label('Not yet published')
                     .defaultValue(false)
             ])

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -267,6 +267,7 @@
             .filters([
                 nga.field('published')
                     .label('Not yet published')
+                    .template(' ')
                     .defaultValue(false)
             ])
             .batchActions([]) // disable checkbox column and batch delete

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.3.2",
+    "admin-config": "^0.4.0",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -46,6 +46,7 @@ CrudModule.directive('maDatagridPagination', require('./list/maDatagridPaginatio
 CrudModule.directive('maDatagridInfinitePagination', require('./list/maDatagridInfinitePagination'));
 CrudModule.directive('maDatagridItemSelector', require('./list/maDatagridItemSelector'));
 CrudModule.directive('maDatagridMultiSelector', require('./list/maDatagridMultiSelector'));
+CrudModule.directive('maFilterForm', require('./filter/maFilterForm'));
 CrudModule.directive('maFilter', require('./filter/maFilter'));
 CrudModule.directive('maFilterButton', require('./filter/maFilterButton'));
 

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -36,6 +36,7 @@ function maColumn($state, $anchorScroll, $compile, Configuration, FieldViewConfi
             scope.datastore = scope.datastore();
             scope.field = scope.field();
             scope.entry = scope.entry();
+            scope.value = scope.entry.values[scope.field.name()];
             scope.entity = scope.entity();
             let customTemplate = scope.field.getTemplateValue(scope.entry);
             if (customTemplate) {

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -42,11 +42,16 @@ define(function (require) {
                 scope.field = scope.field();
                 scope.entry = scope.entry();
                 scope.entity = scope.entity();
-                var type = scope.field.type();
-                if (isDetailLink(scope.field, scope.entity)) {
-                    element.append(FieldViewConfiguration[type].getLinkWidget());
+                let customTemplate = scope.field.getTemplateValue(scope.entry);
+                if (customTemplate) {
+                    element.append(customTemplate);
                 } else {
-                    element.append(FieldViewConfiguration[type].getReadWidget());
+                    let type = scope.field.type();
+                    if (isDetailLink(scope.field, scope.entity)) {
+                        element.append(FieldViewConfiguration[type].getLinkWidget());
+                    } else {
+                        element.append(FieldViewConfiguration[type].getReadWidget());
+                    }
                 }
                 $compile(element.contents())(scope);
                 scope.gotoDetail = function () {

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -1,82 +1,76 @@
-/*global define*/
+function maColumn($state, $anchorScroll, $compile, Configuration, FieldViewConfiguration) {
 
-define(function (require) {
-    'use strict';
-
-    function maColumn($state, $anchorScroll, $compile, Configuration, FieldViewConfiguration) {
-
-        function getDetailLinkRouteName(field, entity) {
-            if (entity.isReadOnly) {
-                return entity.showView().enabled ? 'show' : false;
-            }
-            if (field.detailLinkRoute() == 'edit' && entity.editionView().enabled) {
-                return 'edit';
-            }
+    function getDetailLinkRouteName(field, entity) {
+        if (entity.isReadOnly) {
             return entity.showView().enabled ? 'show' : false;
         }
-
-        function isDetailLink(field, entity) {
-            if (field.isDetailLink() === false) {
-                return false;
-            }
-            if (field.type() == 'reference' || field.type() == 'reference_many') {
-                var relatedEntity = Configuration().getEntity(field.targetEntity().name());
-                if (!relatedEntity) {
-                    return false;
-                }
-                return getDetailLinkRouteName(field, relatedEntity) !== false;
-            }
-            return getDetailLinkRouteName(field, entity) !== false;
+        if (field.detailLinkRoute() == 'edit' && entity.editionView().enabled) {
+            return 'edit';
         }
-
-        return {
-            restrict: 'E',
-            scope: {
-                field: '&',
-                entry: '&',
-                entity: '&',
-                datastore: '&'
-            },
-            link: function(scope, element) {
-                scope.datastore = scope.datastore();
-                scope.field = scope.field();
-                scope.entry = scope.entry();
-                scope.entity = scope.entity();
-                let customTemplate = scope.field.getTemplateValue(scope.entry);
-                if (customTemplate) {
-                    element.append(customTemplate);
-                } else {
-                    let type = scope.field.type();
-                    if (isDetailLink(scope.field, scope.entity)) {
-                        element.append(FieldViewConfiguration[type].getLinkWidget());
-                    } else {
-                        element.append(FieldViewConfiguration[type].getReadWidget());
-                    }
-                }
-                $compile(element.contents())(scope);
-                scope.gotoDetail = function () {
-                    var route = getDetailLinkRouteName(scope.field, scope.entity);
-                    $state.go($state.get(route),
-                    angular.extend({}, $state.params, {
-                        entity: scope.entry.entityName,
-                        id: scope.entry.identifierValue
-                    }));
-                };
-                scope.gotoReference = function () {
-                    var referenceEntity = scope.field.targetEntity().name();
-                    var relatedEntity = Configuration().getEntity(referenceEntity);
-                    var referenceId = scope.entry.values[scope.field.name()];
-                    var route = getDetailLinkRouteName(scope.field, relatedEntity);
-                    $state.go($state.get(route), {
-                        entity: referenceEntity,
-                        id: referenceId
-                    });
-                };
-            }
-        };
+        return entity.showView().enabled ? 'show' : false;
     }
 
-    maColumn.$inject = ['$state', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'FieldViewConfiguration'];
+    function isDetailLink(field, entity) {
+        if (field.isDetailLink() === false) {
+            return false;
+        }
+        if (field.type() == 'reference' || field.type() == 'reference_many') {
+            var relatedEntity = Configuration().getEntity(field.targetEntity().name());
+            if (!relatedEntity) {
+                return false;
+            }
+            return getDetailLinkRouteName(field, relatedEntity) !== false;
+        }
+        return getDetailLinkRouteName(field, entity) !== false;
+    }
 
-    return maColumn;
-});
+    return {
+        restrict: 'E',
+        scope: {
+            field: '&',
+            entry: '&',
+            entity: '&',
+            datastore: '&'
+        },
+        link: function(scope, element) {
+            scope.datastore = scope.datastore();
+            scope.field = scope.field();
+            scope.entry = scope.entry();
+            scope.entity = scope.entity();
+            let customTemplate = scope.field.getTemplateValue(scope.entry);
+            if (customTemplate) {
+                element.append(customTemplate);
+            } else {
+                let type = scope.field.type();
+                if (isDetailLink(scope.field, scope.entity)) {
+                    element.append(FieldViewConfiguration[type].getLinkWidget());
+                } else {
+                    element.append(FieldViewConfiguration[type].getReadWidget());
+                }
+            }
+            $compile(element.contents())(scope);
+            scope.gotoDetail = function () {
+                var route = getDetailLinkRouteName(scope.field, scope.entity);
+                $state.go($state.get(route),
+                angular.extend({}, $state.params, {
+                    entity: scope.entry.entityName,
+                    id: scope.entry.identifierValue
+                }));
+            };
+            scope.gotoReference = function () {
+                var referenceEntity = scope.field.targetEntity().name();
+                var relatedEntity = Configuration().getEntity(referenceEntity);
+                var referenceId = scope.entry.values[scope.field.name()];
+                var route = getDetailLinkRouteName(scope.field, relatedEntity);
+                $state.go($state.get(route), {
+                    entity: referenceEntity,
+                    id: referenceId
+                });
+            };
+        }
+    };
+}
+
+maColumn.$inject = ['$state', '$anchorScroll', '$compile', 'NgAdminConfiguration', 'FieldViewConfiguration'];
+
+module.exports = maColumn;

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -47,7 +47,7 @@ function maField(FieldViewConfiguration, $compile) {
             };
 
             var fieldTemplate;
-            if (scope.field.editable) {
+            if (scope.field.editable()) {
                 fieldTemplate =
 `<div ng-class="getClassesForField(field, entry)">
     ${scope.field.getTemplateValue(scope.entry) || FieldViewConfiguration[scope.type].getWriteWidget()}
@@ -70,8 +70,7 @@ function maField(FieldViewConfiguration, $compile) {
     ${fieldTemplate}
 </div>`;
 
-            element.append(template);
-            $compile(element.contents())(scope);
+            element.append($compile(template)(scope));
         }
     };
 }

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -70,7 +70,8 @@ function maField(FieldViewConfiguration, $compile) {
     ${fieldTemplate}
 </div>`;
 
-            element.append($compile(template)(scope));
+            element.append(template);
+            $compile(element.contents())(scope);
         }
     };
 }

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -4,6 +4,7 @@ function maField(FieldViewConfiguration, $compile) {
         scope: {
             field: '&',
             entry: '=',
+            value: '=',
             entity: '&',
             form: '&',
             datastore: '&'

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -16,33 +16,6 @@ function maField(FieldViewConfiguration, $compile) {
             scope.entity = scope.entity();
             scope.form = scope.form();
             scope.datastore = scope.datastore();
-            var fieldTemplate;
-            if (scope.field.editable) {
-                fieldTemplate =
-`<div ng-class="getClassesForField(field, entry)">
-    ${scope.field.getTemplateValue(scope.entry) || FieldViewConfiguration[scope.type].getWriteWidget()}
-    <span ng-show="fieldHasValidation(field)" class="glyphicon form-control-feedback" ng-class="fieldIsValid(field) ? 'glyphicon-ok' : 'glyphicon-remove'"></span>
-</div>`;
-            } else {
-                fieldTemplate =
-`<div ng-class="field.getCssClasses(entry)||'col-sm-10'">
-    <p class="form-control-static">
-        <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
-    </p>
-</div>`;
-            }
-
-            const template =
-`<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">
-    <label for="{{ field.name() }}" class="col-sm-2 control-label">
-        {{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;
-    </label>
-    ${fieldTemplate}
-</div>`;
-
-            element.append(template);
-            $compile(element.contents())(scope);
-
             scope.getClassesForField = function(field, entry) {
                 return 'ng-admin-field-' + field.name().replace('.', '_') + ' ' + 'ng-admin-type-' + field.type() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');
             };
@@ -74,6 +47,32 @@ function maField(FieldViewConfiguration, $compile) {
                 }
             };
 
+            var fieldTemplate;
+            if (scope.field.editable) {
+                fieldTemplate =
+`<div ng-class="getClassesForField(field, entry)">
+    ${scope.field.getTemplateValue(scope.entry) || FieldViewConfiguration[scope.type].getWriteWidget()}
+    <span ng-show="fieldHasValidation(field)" class="glyphicon form-control-feedback" ng-class="fieldIsValid(field) ? 'glyphicon-ok' : 'glyphicon-remove'"></span>
+</div>`;
+            } else {
+                fieldTemplate =
+`<div ng-class="field.getCssClasses(entry)||'col-sm-10'">
+    <p class="form-control-static">
+        <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+    </p>
+</div>`;
+            }
+
+            const template =
+`<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">
+    <label for="{{ field.name() }}" class="col-sm-2 control-label">
+        {{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;
+    </label>
+    ${fieldTemplate}
+</div>`;
+
+            element.append(template);
+            $compile(element.contents())(scope);
         }
     };
 }

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -1,5 +1,3 @@
-var _ = require('lodash');
-
 function maField(FieldViewConfiguration, $compile) {
     return {
         restrict: 'E',

--- a/src/javascripts/ng-admin/Crud/field/maField.js
+++ b/src/javascripts/ng-admin/Crud/field/maField.js
@@ -1,25 +1,6 @@
 var _ = require('lodash');
 
-function maField(FieldViewConfiguration) {
-    var writeWidgetTypes = _(FieldViewConfiguration)
-        .map(function(fieldView, field) {
-            return '<span ng-switch-when="' + field + '">' + fieldView.getWriteWidget() +'</span>';
-        }).join('');
-    var template =
-'<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">' +
-'<label for="{{ field.name() }}" class="col-sm-2 control-label">' +
-    '{{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;' +
-'</label>' +
-'<div ng-if="field.editable()" ng-class="getClassesForField(field, entry)" ng-switch="field.type()">' +
-    writeWidgetTypes +
-    '<span ng-show="fieldHasValidation(field)" class="glyphicon form-control-feedback" ng-class="fieldIsValid(field) ? \'glyphicon-ok\' : \'glyphicon-remove\'"></span>' +
-'</div>' +
-'<div ng-if="!field.editable()" ng-class="field.getCssClasses(entry)||\'col-sm-10\'">' +
-    '<p class="form-control-static">' +
-        '<ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>' +
-    '</p>' +
-'</div>' +
-'</div>';
+function maField(FieldViewConfiguration, $compile) {
     return {
         restrict: 'E',
         scope: {
@@ -29,12 +10,38 @@ function maField(FieldViewConfiguration) {
             form: '&',
             datastore: '&'
         },
-        link: function(scope) {
+        link: function(scope, element) {
             scope.field = scope.field();
             scope.type = scope.field.type();
             scope.entity = scope.entity();
             scope.form = scope.form();
             scope.datastore = scope.datastore();
+            var fieldTemplate;
+            if (scope.field.editable) {
+                fieldTemplate =
+`<div ng-class="getClassesForField(field, entry)">
+    ${scope.field.getTemplateValue(scope.entry) || FieldViewConfiguration[scope.type].getWriteWidget()}
+    <span ng-show="fieldHasValidation(field)" class="glyphicon form-control-feedback" ng-class="fieldIsValid(field) ? 'glyphicon-ok' : 'glyphicon-remove'"></span>
+</div>`;
+            } else {
+                fieldTemplate =
+`<div ng-class="field.getCssClasses(entry)||'col-sm-10'">
+    <p class="form-control-static">
+        <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+    </p>
+</div>`;
+            }
+
+            const template =
+`<div id="row-{{ field.name() }}" class="has-feedback" ng-class="getFieldValidationClass(field)">
+    <label for="{{ field.name() }}" class="col-sm-2 control-label">
+        {{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;
+    </label>
+    ${fieldTemplate}
+</div>`;
+
+            element.append(template);
+            $compile(element.contents())(scope);
 
             scope.getClassesForField = function(field, entry) {
                 return 'ng-admin-field-' + field.name().replace('.', '_') + ' ' + 'ng-admin-type-' + field.type() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7');
@@ -67,11 +74,10 @@ function maField(FieldViewConfiguration) {
                 }
             };
 
-        },
-        template: template
+        }
     };
 }
 
-maField.$inject = ['FieldViewConfiguration'];
+maField.$inject = ['FieldViewConfiguration', '$compile'];
 
 module.exports = maField;

--- a/src/javascripts/ng-admin/Crud/field/maTemplateField.js
+++ b/src/javascripts/ng-admin/Crud/field/maTemplateField.js
@@ -10,7 +10,8 @@ define(function (require) {
                 field: '&',
                 entry: '&',
                 entity: '&',
-                value: '='
+                value: '=',
+                values: '='
             },
             link: function(scope) {
                 scope.field = scope.field();

--- a/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
@@ -1,9 +1,9 @@
 module.exports = {
-    getReadWidget:   () => '<ma-boolean-column value="::entry.values[field.name()]"></ma-boolean-column>',
+    getReadWidget:   () => '<ma-boolean-column value="::value]"></ma-boolean-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => `<ma-choice-field field="::field" value="values[field.name()]" choices="[{value: 'true', label: 'true' }, { value: 'false', label: 'false' }]"></ma-choice-field>`,
+    getFilterWidget: () => `<ma-choice-field field="::field" value="value" choices="[{value: 'true', label: 'true' }, { value: 'false', label: 'false' }]"></ma-choice-field>`,
     getWriteWidget:  () => `<div class="row">
-        <ma-choice-field class="col-sm-4 col-md-3" ng-if="!field.validation().required" field="::field" value="entry.values[field.name()]"></ma-choice-field>
-        <ma-checkbox-field class="col-sm-4 col-md-3" ng-if="!!field.validation().required" field="::field" value="entry.values[field.name()]"></ma-checkbox-field>
+        <ma-choice-field class="col-sm-4 col-md-3" ng-if="!field.validation().required" field="::field" value="value"></ma-choice-field>
+        <ma-checkbox-field class="col-sm-4 col-md-3" ng-if="!!field.validation().required" field="::field" value="value"></ma-checkbox-field>
     </div>`
 }

--- a/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
@@ -1,5 +1,5 @@
 module.exports = {
-    getReadWidget:   () => '<ma-boolean-column value="::value]"></ma-boolean-column>',
+    getReadWidget:   () => '<ma-boolean-column value="::value"></ma-boolean-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
     getFilterWidget: () => `<ma-choice-field field="::field" value="value" choices="[{value: 'true', label: 'true' }, { value: 'false', label: 'false' }]"></ma-choice-field>`,
     getWriteWidget:  () => `<div class="row">

--- a/src/javascripts/ng-admin/Crud/fieldView/ChoiceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ChoiceFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-string-column value="::field.getLabelForChoice(entry.values[field.name()], entry)"></ma-string-column>',
+    getReadWidget:   () => '<ma-string-column value="::field.getLabelForChoice(value, entry)"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-choice-field field="::field" value="values[field.name()]"></ma-choice-field>',
-    getWriteWidget:  () => '<ma-choice-field field="::field" entry="entry" value="entry.values[field.name()]"></ma-choice-field>'
+    getFilterWidget: () => '<ma-choice-field field="::field" value="value"></ma-choice-field>',
+    getWriteWidget:  () => '<ma-choice-field field="::field" entry="entry" value="value"></ma-choice-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ChoicesFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ChoicesFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-choices-column values="::entry.values[field.name()]"></ma-choices-column>',
+    getReadWidget:   () => '<ma-choices-column values="::value"></ma-choices-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-choices-field field="::field" value="values[field.name()]"></ma-choices-field>',
-    getWriteWidget:  () => '<ma-choices-field field="::field" entry="::entry" value="entry.values[field.name()]"></ma-choices-field>'
+    getFilterWidget: () => '<ma-choices-field field="::field" value="value"></ma-choices-field>',
+    getWriteWidget:  () => '<ma-choices-field field="::field" entry="::entry" value="value"></ma-choices-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/DateFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/DateFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-date-column field="::field" value="::entry.values[field.name()]"></ma-date-column>',
+    getReadWidget:   () => '<ma-date-column field="::field" value="::value"></ma-date-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-date-field field="::field" value="values[field.name()]"></ma-date-field>',
-    getWriteWidget:  () => '<div class="row"><div class="col-sm-5 col-lg-4"><ma-date-field field="::field" value="entry.values[field.name()]"></ma-date-field></div></div>'
+    getFilterWidget: () => '<ma-date-field field="::field" value="value"></ma-date-field>',
+    getWriteWidget:  () => '<div class="row"><div class="col-sm-5 col-lg-4"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/DateTimeFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/DateTimeFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-date-column field="::field" value="::entry.values[field.name()]"></ma-date-column>',
+    getReadWidget:   () => '<ma-date-column field="::field" value="::value"></ma-date-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-date-field field="::field" value="values[field.name()]"></ma-date-field>',
-    getWriteWidget:  () => '<div class="row"><div class="col-sm-7 col-lg-6"><ma-date-field field="::field" value="entry.values[field.name()]"></ma-date-field></div></div>'
+    getFilterWidget: () => '<ma-date-field field="::field" value="value"></ma-date-field>',
+    getWriteWidget:  () => '<div class="row"><div class="col-sm-7 col-lg-6"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/EmailFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/EmailFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-string-column value="::entry.values[field.name()]"></ma-string-column>',
+    getReadWidget:   () => '<ma-string-column value="::value"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-input-field type="email" field="::field" value="entry.values[field.name()]"></ma-input-field>'
+    getFilterWidget: () => '<ma-input-field field="::field" value="value"></ma-input-field>',
+    getWriteWidget:  () => '<ma-input-field type="email" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/FileFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/FileFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => 'error: cannot display file field as readable',
     getLinkWidget:   () => 'error: cannot display file field as linkable',
     getFilterWidget: () => 'error: cannot display file field as filter',
-    getWriteWidget:  () => '<ma-file-field field="::field" value="entry.values[field.name()]"></ma-file-field>'
+    getWriteWidget:  () => '<ma-file-field field="::field" value="value"></ma-file-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/FloatFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/FloatFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-number-column field="::field" value="::value"></ma-number-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: module.exports.getWriteWidget,
+    getFilterWidget: () => '<ma-input-field type="number" step="any" field="::field" value="value"></ma-input-field>',
     getWriteWidget:  () => '<ma-input-field type="number" step="any" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/FloatFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/FloatFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column>',
+    getReadWidget:   () => '<ma-number-column field="::field" value="::value"></ma-number-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field type="number" step="any" field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-input-field type="number" step="any" field="::field" value="entry.values[field.name()]"></ma-input-field>'
+    getFilterWidget: module.exports.getWriteWidget,
+    getWriteWidget:  () => '<ma-input-field type="number" step="any" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/JsonFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/JsonFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-json-column value="::entry.values[field.name()]"></ma-json-column>',
+    getReadWidget:   () => '<ma-json-column value="::value"></ma-json-column>',
     getLinkWidget:   () => 'error: cannot display a json field as linkable',
-    getFilterWidget: () => '<ma-input-field field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-json-field field="::field" value="entry.values[field.name()]"></ma-json-field>'
+    getFilterWidget: () => '<ma-input-field field="::field" value="value"></ma-input-field>',
+    getWriteWidget:  () => '<ma-json-field field="::field" value="value"></ma-json-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-number-column field="::field" value="::entry.values[field.name()]"></ma-number-column>',
+    getReadWidget:   () => '<ma-number-column field="::field" value="::value"></ma-number-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field type="number" field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-input-field type="number" field="::field" value="entry.values[field.name()]"></ma-input-field>'
+    getFilterWidget: module.exports.getWriteWidget,
+    getWriteWidget:  () => '<ma-input-field type="number" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/NumberFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-number-column field="::field" value="::value"></ma-number-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: module.exports.getWriteWidget,
+    getFilterWidget: () => '<ma-input-field type="number" field="::field" value="value"></ma-input-field>',
     getWriteWidget:  () => '<ma-input-field type="number" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/PasswordFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/PasswordFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => 'error: cannot display password field as readable',
     getLinkWidget:   () => 'error: cannot display password field as linkable',
     getFilterWidget: () => 'error: cannot display password field as filter',
-    getWriteWidget:  () => '<ma-input-field type="password" field="::field" value="entry.values[field.name()]"></ma-input-field>'
+    getWriteWidget:  () => '<ma-input-field type="password" field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-reference-column field="::field" value="::value" datastore="::datastore"></ma-reference-column>',
     getLinkWidget:   () => '<a ng-click="gotoReference()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: module.exports.getWriteWidget,
+    getFilterWidget: () => '<ma-reference-field field="::field" value="value" datastore="::datastore"></ma-reference-field>',
     getWriteWidget:  () => '<ma-reference-field field="::field" value="value" datastore="::datastore"></ma-reference-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-reference-column field="::field" value="::value" datastore="::datastore"></ma-reference-column>',
     getLinkWidget:   () => '<a ng-click="gotoReference()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => module.exports.getWriteWidget,
+    getFilterWidget: module.exports.getWriteWidget,
     getWriteWidget:  () => '<ma-reference-field field="::field" value="value" datastore="::datastore"></ma-reference-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-reference-column field="::field" value="::entry.values[field.name()]" datastore="::datastore"></ma-reference-column>',
+    getReadWidget:   () => '<ma-reference-column field="::field" value="::value" datastore="::datastore"></ma-reference-column>',
     getLinkWidget:   () => '<a ng-click="gotoReference()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-reference-field field="::field" value="values[field.name()]" datastore="::datastore"></ma-reference-field>',
-    getWriteWidget:  () => '<ma-reference-field field="::field" value="entry.values[field.name()]" datastore="::datastore"></ma-reference-field>'
+    getFilterWidget: () => module.exports.getWriteWidget,
+    getWriteWidget:  () => '<ma-reference-field field="::field" value="value" datastore="::datastore"></ma-reference-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferenceManyFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferenceManyFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-choices-column values="::entry.listValues[field.name()]"></ma-choices-column>',
-    getLinkWidget:   () => '<ma-reference-many-link-column ids="::entry.values[field.name()]" values="::entry.listValues[field.name()]" field="::field"></ma-reference-many-link-column>',
-    getFilterWidget: () => '<ma-choices-field field="::field" value="values[field.name()]" datastore="::datastore"></ma-choices-field>',
-    getWriteWidget:  () => '<ma-reference-many-field field="::field" value="entry.values[field.name()]" datastore="::datastore"></ma-reference-many-field>'
+    getLinkWidget:   () => '<ma-reference-many-link-column ids="::value" values="::entry.listValues[field.name()]" field="::field"></ma-reference-many-link-column>',
+    getFilterWidget: () => '<ma-choices-field field="::field" value="value" datastore="::datastore"></ma-choices-field>',
+    getWriteWidget:  () => '<ma-reference-many-field field="::field" value="value" datastore="::datastore"></ma-reference-many-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => '<ma-referenced-list-column field="::field" datastore="::datastore"></ma-referenced-list-column>',
     getLinkWidget:   () => 'error: cannot display referenced_list field as linkable',
     getFilterWidget: () => 'error: cannot display referenced_list field as filter',
-    getWriteWidget:  () => module.exports.getReadWidget
+    getWriteWidget:  module.exports.getReadWidget
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => '<ma-referenced-list-column field="::field" datastore="::datastore"></ma-referenced-list-column>',
     getLinkWidget:   () => 'error: cannot display referenced_list field as linkable',
     getFilterWidget: () => 'error: cannot display referenced_list field as filter',
-    getWriteWidget:  () => '<ma-referenced-list-column field="::field" datastore="::datastore"></ma-referenced-list-column>'
+    getWriteWidget:  () => module.exports.getReadWidget
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/ReferencedListFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => '<ma-referenced-list-column field="::field" datastore="::datastore"></ma-referenced-list-column>',
     getLinkWidget:   () => 'error: cannot display referenced_list field as linkable',
     getFilterWidget: () => 'error: cannot display referenced_list field as filter',
-    getWriteWidget:  module.exports.getReadWidget
+    getWriteWidget:  () => '<ma-referenced-list-column field="::field" datastore="::datastore"></ma-referenced-list-column>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-string-column value="::value"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => module.exports.getWriteWidget,
+    getFilterWidget: module.exports.getWriteWidget,
     getWriteWidget:  () => '<ma-input-field field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-string-column value="::entry.values[field.name()]"></ma-string-column>',
+    getReadWidget:   () => '<ma-string-column value="::value"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-input-field field="::field" value="entry.values[field.name()]"></ma-input-field>'
+    getFilterWidget: () => module.exports.getWriteWidget,
+    getWriteWidget:  () => '<ma-input-field field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/StringFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-string-column value="::value"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: module.exports.getWriteWidget,
+    getFilterWidget: () => '<ma-input-field field="::field" value="value"></ma-input-field>',
     getWriteWidget:  () => '<ma-input-field field="::field" value="value"></ma-input-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/TemplateFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/TemplateFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
     getReadWidget:   () => '<ma-template-column entry="::entry" field="::field" entity="::entity"></ma-template-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-template-field field="::field" value="values[field.name()]" values="values" filters="filters"></ma-template-field>',
-    getWriteWidget:  () => '<ma-template-field entry="entry" field="::field" entity="::entity"></ma-template-field>'
+    getFilterWidget: () => '<ma-template-field field="::field" value="value" values="values" filters="filters"></ma-template-field>',
+    getWriteWidget:  () => '<ma-template-field field="::field" value="value" entry="entry" entity="::entity"></ma-template-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/TextFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/TextFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-string-column value="::entry.values[field.name()]"></ma-string-column>',
+    getReadWidget:   () => '<ma-string-column value="::value"></ma-string-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-text-field field="::field" value="entry.values[field.name()]"></ma-text-field>'
+    getFilterWidget: () => '<ma-input-field field="::field" value="value"></ma-input-field>',
+    getWriteWidget:  () => '<ma-text-field field="::field" value="value"></ma-text-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/WysiwygFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/WysiwygFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-wysiwyg-column field="::field" value="::entry.values[field.name()]"></ma-wysiwyg-column>',
+    getReadWidget:   () => '<ma-wysiwyg-column field="::field" value="::value"></ma-wysiwyg-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => '<ma-input-field field="::field" value="values[field.name()]"></ma-input-field>',
-    getWriteWidget:  () => '<ma-wysiwyg-field field="::field" value="entry.values[field.name()]"></ma-wysiwyg-field>'
+    getFilterWidget: () => '<ma-input-field field="::field" value="value"></ma-input-field>',
+    getWriteWidget:  () => '<ma-wysiwyg-field field="::field" value="value"></ma-wysiwyg-field>'
 };

--- a/src/javascripts/ng-admin/Crud/filter/maFilter.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilter.js
@@ -1,48 +1,20 @@
-var _ = require('lodash');
-
-function maFilterDirective(FieldViewConfiguration) {
-    'use strict';
-
-    var filterWidgetTypes = _(FieldViewConfiguration)
-        .map(function(fieldView, field) {
-            return '<span ng-switch-when="' + field + '">' + fieldView.getFilterWidget() +'</span>';
-        }).join('');
-
-    var template = `
-<div class="row">
-    <form class="filters col-md-offset-6 col-md-6 form-horizontal" ng-if="shouldFilter()">
-        <div class="filter {{ field.name() }} form-group input-{{ field.type() }}" ng-repeat="field in filters track by field.name()">
-            <div class="col-sm-1 col-xs-1 remove_filter">
-                <a ng-if="!field.pinned()" ng-click="removeFilter(field)"><span class="glyphicon glyphicon-remove"></span></a>
-            </div>
-            <label for="{{ field.name() }}" class="col-sm-4 col-xs-11 control-label">
-                {{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;
-            </label>
-            <div class="col-sm-7" ng-switch="field.type()" ng-class="field.getCssClasses(entry)">
-                ${filterWidgetTypes}
-            </div>
-        </div>
-    </form>
-</div>
-    `;
-
+function maFilterDirective(FieldViewConfiguration, $compile) {
     return {
         restrict: 'E',
-        template: template,
         scope: {
-            filters: '=',
+            field: '=',
             datastore: '&',
             values: '=',
-            removeFilter: '&'
+            value: '='
         },
-        link: function(scope) {
+        link: function(scope, element) {
             scope.datastore = scope.datastore();
-            scope.removeFilter = scope.removeFilter();
-            scope.shouldFilter = () => Object.keys(scope.filters).length;
+            element.append(scope.field.getTemplateValue(scope.values) || FieldViewConfiguration[scope.field.type()].getFilterWidget());
+            $compile(element.contents())(scope);
         }
     };
 }
 
-maFilterDirective.$inject = ['FieldViewConfiguration'];
+maFilterDirective.$inject = ['FieldViewConfiguration', '$compile'];
 
 module.exports = maFilterDirective;

--- a/src/javascripts/ng-admin/Crud/filter/maFilterForm.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilterForm.js
@@ -1,0 +1,36 @@
+function maFilterFormDirective() {
+    return {
+        restrict: 'E',
+        scope: {
+            filters: '=',
+            datastore: '&',
+            values: '=',
+            removeFilter: '&'
+        },
+        link: function(scope, element) {
+            scope.datastore = scope.datastore();
+            scope.removeFilter = scope.removeFilter();
+            scope.shouldFilter = () => Object.keys(scope.filters).length;
+        },
+        template:
+`<div class="row">
+    <form class="filters col-md-offset-6 col-md-6 form-horizontal" ng-if="shouldFilter()">
+        <div class="filter {{ field.name() }} form-group input-{{ field.type() }}" ng-repeat="field in filters track by field.name()">
+            <div class="col-sm-1 col-xs-1 remove_filter">
+                <a ng-if="!field.pinned()" ng-click="removeFilter(field)"><span class="glyphicon glyphicon-remove"></span></a>
+            </div>
+            <label for="{{ field.name() }}" class="col-sm-4 col-xs-11 control-label">
+                {{ field.label() }}<span ng-if="field.validation().required">&nbsp;*</span>&nbsp;
+            </label>
+            <div class="col-sm-7" ng-switch="field.type()" ng-class="field.getCssClasses(entry)">
+                <ma-filter field="::field" value="values[field.name()]" values="values" datastore="datastore"></ma-filter>
+            </div>
+        </div>
+    </form>
+</div>`
+    };
+}
+
+maFilterFormDirective.$inject = [];
+
+module.exports = maFilterFormDirective;

--- a/src/javascripts/ng-admin/Crud/form/create.html
+++ b/src/javascripts/ng-admin/Crud/form/create.html
@@ -15,7 +15,7 @@
 <div class="row" id="create-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitCreation($event)">
         <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+            <ma-field field="::field" value="entry.values[field.name()]" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
         </div>
 
         <div class="form-group">

--- a/src/javascripts/ng-admin/Crud/form/edit.html
+++ b/src/javascripts/ng-admin/Crud/form/edit.html
@@ -16,7 +16,7 @@
 <div class="row" id="edit-view" ng-class="::'ng-admin-entity-' + formController.entity.name()">
     <form class="col-lg-12 form-horizontal" name="formController.form" ng-submit="formController.submitEdition($event)">
         <div class="form-field form-group" ng-repeat="field in ::formController.fields track by $index">
-            <ma-field field="::field" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
+            <ma-field field="::field" value="entry.values[field.name()]" entry="entry" entity="::entity" form="formController.form" datastore="::formController.dataStore"></ma-field>
         </div>
 
         <div class="form-group">

--- a/src/javascripts/ng-admin/Crud/list/listLayout.html
+++ b/src/javascripts/ng-admin/Crud/list/listLayout.html
@@ -15,7 +15,7 @@
             <p class="lead" ng-if="::llCtrl.view.description()" compile="::llCtrl.view.description()">{{ ::llCtrl.view.description() }}</p>
         </div>
 
-        <ma-filter ng-if="llCtrl.hasFilters" filters="llCtrl.enabledFilters" values="llCtrl.search" datastore="::llCtrl.dataStore" remove-filter="::llCtrl.removeFilter"></ma-filter>
+        <ma-filter-form ng-if="llCtrl.hasFilters" filters="llCtrl.enabledFilters" values="llCtrl.search" datastore="::llCtrl.dataStore" remove-filter="::llCtrl.removeFilter"></ma-filter-form>
 
     </div>
 </div>

--- a/src/javascripts/test/e2e/validationSpec.js
+++ b/src/javascripts/test/e2e/validationSpec.js
@@ -9,16 +9,16 @@ describe('Form validation', function () {
 
         it('should not display any validation status before entering data', function () {
             var enclosingDiv = element.all(by.css('.has-feedback')).first();
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope');
         });
 
         it('should display correct validation status once data is entered', function () {
             var input = element.all(by.css('input')).first();
             var enclosingDiv = element.all(by.css('.has-feedback')).first();
             input.sendKeys('ra');
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback has-error');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope has-error');
             input.sendKeys('rabisudbfij');
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback has-success');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope has-success');
         });
     });
 
@@ -29,7 +29,7 @@ describe('Form validation', function () {
 
         it('should not display any validation status before entering data', function () {
             var enclosingDiv = element.all(by.css('.has-feedback')).first();
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope');
         });
 
         it('should display correct validation status once data is entered', function () {
@@ -37,9 +37,9 @@ describe('Form validation', function () {
             var enclosingDiv = element.all(by.css('.has-feedback')).first();
             input.clear();
             input.sendKeys('ra');
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback has-error');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope has-error');
             input.sendKeys('rabisudbfij');
-            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback has-success');
+            expect(enclosingDiv.getAttribute('class')).toBe('has-feedback ng-scope has-success');
         });
     });
 

--- a/src/javascripts/test/unit/Crud/column/maColumnSpec.js
+++ b/src/javascripts/test/unit/Crud/column/maColumnSpec.js
@@ -1,0 +1,48 @@
+/*global angular,inject,describe,it,expect,beforeEach*/
+describe('directive: ma-column', function () {
+    'use strict';
+
+    var directive = require('../../../../ng-admin/Crud/column/maColumn');
+    var Field = require('admin-config/lib/Field/Field');
+    angular.module('testapp_Column', [])
+        .directive('maColumn', directive)
+        .service('FieldViewConfiguration', function() {
+            return { string: { getReadWidget: function() { return 'DUMMY'; } } }
+        })
+        .service('$state', function() { return {}; })
+        .service('$anchorScroll', function() { return {}; })
+        .service('NgAdminConfiguration', function() { return {}; });
+
+    var $compile,
+        scope,
+        directiveUsage = '<ma-column field="::field" entry="entry" entity="::entity" datastore="::dataStore"></ma-column>';
+
+    beforeEach(angular.mock.module('testapp_Column'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    it("should render the ReadWidget from the fieldView Configuration for that type", function () {
+        scope.field = new Field('foo');
+        scope.entity = {};
+        scope.entry = { values: [] };
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html()).toContain('DUMMY');
+    });
+
+    it("should render the Field template instead of the ReadWidget when set", function () {
+        scope.field = new Field('foo').template('YOPLA');
+        scope.entity = {};
+        scope.entry = { values: [] };
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html()).not.toContain('DUMMY');
+        expect(element.html()).toContain('YOPLA');
+    });
+
+});

--- a/src/javascripts/test/unit/Crud/column/maColumnSpec.js
+++ b/src/javascripts/test/unit/Crud/column/maColumnSpec.js
@@ -6,12 +6,10 @@ describe('directive: ma-column', function () {
     var Field = require('admin-config/lib/Field/Field');
     angular.module('testapp_Column', [])
         .directive('maColumn', directive)
-        .service('FieldViewConfiguration', function() {
-            return { string: { getReadWidget: function() { return 'DUMMY'; } } }
-        })
-        .service('$state', function() { return {}; })
-        .service('$anchorScroll', function() { return {}; })
-        .service('NgAdminConfiguration', function() { return {}; });
+        .service('FieldViewConfiguration', () => ({ string: { getReadWidget: () => 'DUMMY' } }))
+        .service('$state', () => ({}))
+        .service('$anchorScroll', () => ({}))
+        .service('NgAdminConfiguration', () => ({}));
 
     var $compile,
         scope,
@@ -26,9 +24,7 @@ describe('directive: ma-column', function () {
 
     it("should render the ReadWidget from the fieldView Configuration for that type", function () {
         scope.field = new Field('foo');
-        scope.entity = {};
-        scope.entry = { values: [] };
-        scope.dataStore = {};
+        scope.entry = { values: { foo: null } };
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).toContain('DUMMY');
@@ -36,9 +32,7 @@ describe('directive: ma-column', function () {
 
     it("should render the Field template instead of the ReadWidget when set", function () {
         scope.field = new Field('foo').template('YOPLA');
-        scope.entity = {};
-        scope.entry = { values: [] };
-        scope.dataStore = {};
+        scope.entry = { values: { foo: null } };
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).not.toContain('DUMMY');

--- a/src/javascripts/test/unit/Crud/field/maField.js
+++ b/src/javascripts/test/unit/Crud/field/maField.js
@@ -1,0 +1,47 @@
+/*global angular,inject,describe,it,expect,beforeEach*/
+describe('directive: ma-field', function () {
+    'use strict';
+
+    var directive = require('../../../../ng-admin/Crud/field/maField');
+    var Field = require('admin-config/lib/Field/Field');
+    angular.module('testapp_Field', [])
+        .directive('maField', directive)
+        .service('FieldViewConfiguration', function() {
+            return { string: { getWriteWidget: function() { return 'DUMMY'; } } }
+        });
+
+    var $compile,
+        scope,
+        directiveUsage = '<ma-field field="::field" entry="entry" entity="::entity" form="form" datastore="::dataStore"></ma-field>';
+
+    beforeEach(angular.mock.module('testapp_Field'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    it("should render the WriteWidget from the fieldView Configuration for that type", function () {
+        scope.field = new Field('foo');
+        scope.entity = {};
+        scope.entry = { values: [] };
+        scope.form = { foo: {} };
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html().indexOf('DUMMY')).not.toBe(-1);
+    });
+
+    it("should render the Field template instead of the WriteWidget when set", function () {
+        scope.field = new Field('foo').template('YOPLA');
+        scope.entity = {};
+        scope.entry = { values: [] };
+        scope.form = { foo: {} };
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html().indexOf('DUMMY')).toBe(-1);
+        expect(element.html().indexOf('YOPLA')).not.toBe(-1);
+    });
+
+});

--- a/src/javascripts/test/unit/Crud/field/maFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maFieldSpec.js
@@ -29,7 +29,7 @@ describe('directive: ma-field', function () {
         scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
-        expect(element.html().indexOf('DUMMY')).not.toBe(-1);
+        expect(element.html()).toContain('DUMMY');
     });
 
     it("should render the Field template instead of the WriteWidget when set", function () {
@@ -40,8 +40,8 @@ describe('directive: ma-field', function () {
         scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
-        expect(element.html().indexOf('DUMMY')).toBe(-1);
-        expect(element.html().indexOf('YOPLA')).not.toBe(-1);
+        expect(element.html()).not.toContain('DUMMY');
+        expect(element.html()).toContain('YOPLA');
     });
 
 });

--- a/src/javascripts/test/unit/Crud/field/maFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maFieldSpec.js
@@ -6,9 +6,7 @@ describe('directive: ma-field', function () {
     var Field = require('admin-config/lib/Field/Field');
     angular.module('testapp_Field', [])
         .directive('maField', directive)
-        .service('FieldViewConfiguration', function() {
-            return { string: { getWriteWidget: function() { return 'DUMMY'; } } }
-        });
+        .service('FieldViewConfiguration', () => ({ string: { getWriteWidget: () => 'DUMMY' } }));
 
     var $compile,
         scope,
@@ -23,10 +21,7 @@ describe('directive: ma-field', function () {
 
     it("should render the WriteWidget from the fieldView Configuration for that type", function () {
         scope.field = new Field('foo');
-        scope.entity = {};
-        scope.entry = { values: [] };
         scope.form = { foo: {} };
-        scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).toContain('DUMMY');
@@ -34,10 +29,7 @@ describe('directive: ma-field', function () {
 
     it("should render the Field template instead of the WriteWidget when set", function () {
         scope.field = new Field('foo').template('YOPLA');
-        scope.entity = {};
-        scope.entry = { values: [] };
         scope.form = { foo: {} };
-        scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).not.toContain('DUMMY');

--- a/src/javascripts/test/unit/Crud/filter/maFilterSpec.js
+++ b/src/javascripts/test/unit/Crud/filter/maFilterSpec.js
@@ -6,9 +6,7 @@ describe('directive: ma-filter', function () {
     var Field = require('admin-config/lib/Field/Field');
     angular.module('testapp_Filter', [])
         .directive('maFilter', directive)
-        .service('FieldViewConfiguration', function() {
-            return { string: { getFilterWidget: function() { return 'DUMMY'; } } }
-        });
+        .service('FieldViewConfiguration', () => ({ string: { getFilterWidget: () => 'DUMMY' } }));
 
     var $compile,
         scope,
@@ -23,9 +21,6 @@ describe('directive: ma-filter', function () {
 
     it("should render the FilterWidget from the fieldView Configuration for that type", function () {
         scope.field = new Field('foo');
-        scope.values = [];
-        scope.value = '';
-        scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).toContain('DUMMY');
@@ -33,9 +28,6 @@ describe('directive: ma-filter', function () {
 
     it("should render the Field template instead of the FilterWidget when set", function () {
         scope.field = new Field('foo').template('YOPLA');
-        scope.values = [];
-        scope.value = '';
-        scope.dataStore = {};
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.html()).not.toContain('DUMMY');

--- a/src/javascripts/test/unit/Crud/filter/maFilterSpec.js
+++ b/src/javascripts/test/unit/Crud/filter/maFilterSpec.js
@@ -1,0 +1,45 @@
+/*global angular,inject,describe,it,expect,beforeEach*/
+describe('directive: ma-filter', function () {
+    'use strict';
+
+    var directive = require('../../../../ng-admin/Crud/filter/maFilter');
+    var Field = require('admin-config/lib/Field/Field');
+    angular.module('testapp_Filter', [])
+        .directive('maFilter', directive)
+        .service('FieldViewConfiguration', function() {
+            return { string: { getFilterWidget: function() { return 'DUMMY'; } } }
+        });
+
+    var $compile,
+        scope,
+        directiveUsage = '<ma-filter field="::field" values="values" value="value" datastore="::dataStore"></ma-filter>';
+
+    beforeEach(angular.mock.module('testapp_Filter'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    it("should render the FilterWidget from the fieldView Configuration for that type", function () {
+        scope.field = new Field('foo');
+        scope.values = [];
+        scope.value = '';
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html()).toContain('DUMMY');
+    });
+
+    it("should render the Field template instead of the FilterWidget when set", function () {
+        scope.field = new Field('foo').template('YOPLA');
+        scope.values = [];
+        scope.value = '';
+        scope.dataStore = {};
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.html()).not.toContain('DUMMY');
+        expect(element.html()).toContain('YOPLA');
+    });
+
+});


### PR DESCRIPTION
Now all field types have a `.template()` method - so the need to create a custom type becomes quite rare. 

- [x] make it work
- [x] add tests
- [x] add doc

In the process of clarifying which variables are available for templates in all situations, I added `value` everywhere, and it simplifies fieldViews a lot.