### PR TITLE
[RFR] Introducing the embedded_list field type

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,7 @@
   "esnext": true,
   "bitwise": true,
   "camelcase": true,
-  "curly": true,
+  "curly": false,
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
@@ -14,7 +14,7 @@
   "regexp": true,
   "undef": true,
   "unused": true,
-  "strict": true,
+  "strict": false,
   "trailing": true,
   "smarttabs": true,
   "globals": {

--- a/doc/Configuration-reference.md
+++ b/doc/Configuration-reference.md
@@ -989,6 +989,27 @@ GET /comments/124
 }
 ```
 
+Then mapping a `comments` property of the `post` entity to a `reference_many` will tell ng-admin to fetch the related `comment` entities.
+
+```js
+var post = nga.entity('posts');
+var comment = nga.entity('comments');
+post.editionView().fields([
+    nga.field('comments', 'reference_many') // Define a 1-N relationship with the comment entity
+        .targetEntity(comment) // Target the comment Entity
+        .targetFieldField('body') // the field of the comment entity to use as representation
+]);
+```
+
+` reference_many` fields render as a list of labels in rerad context (`listView` and `showView`), and as a select multiple in write context (`creationView` and `editionView`). For that field, ng-admin fetches the related entities one by one:
+
+```
+GET /posts/456 <= get the main entity
+{ "id": "456", "comments": [123, 124], ... }
+GET /comments/123
+GET /comments/124
+```
+
 The `reference_many` field type also defines `label`, `order`, `map` & `validation` options like the `Field` type.
 
 * `targetEntity(Entity)`
@@ -1006,7 +1027,7 @@ Define the field name used to link the referenced entity.
         ])
 
 * `singleApiCall(function(entityIds) {}`
-Define a function that returns parameters for filtering API calls. You can use it if you API support filter for multiple values.
+Define a function that returns parameters for filtering API calls. You can use it if you API supports filter for multiple values.
 
         // Will call /tags?tag_id[]=1&tag_id[]=2&tag_id%[]=5...
         postList.fields([

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -158,9 +158,9 @@
                     .cssClasses('col-sm-4'),
                 nga.field('backlinks', 'embedded_list') // display embedded list
                     .targetFields([
-                        nga.field('date', 'datetime')
-                            .template('<div class="row"><div class="col-lg-8"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'),
+                        nga.field('date', 'datetime'),
                         nga.field('url')
+                            .cssClasses('col-lg-10')
                     ])
                     .sortField('date')
                     .sortDir('DESC'),

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -97,6 +97,10 @@
                     .cssClasses('hidden-xs'),
                 nga.field('views', 'number')
                     .cssClasses('hidden-xs'),
+                nga.field('backlinks', 'embedded_list') // display list of related comments
+                    .label('Links')
+                    .map(links => links ? links.length : '')
+                    .template('{{ value }}'),
                 nga.field('tags', 'reference_many') // a Reference is a particular type of field that references another entity
                     .targetEntity(tag) // the tag entity is defined later in this file
                     .targetField(nga.field('name')) // the field to be displayed in this list
@@ -152,44 +156,61 @@
                     .cssClasses('col-sm-4'),
                 nga.field('average_note', 'float')
                     .cssClasses('col-sm-4'),
-                nga.field('comments', 'embedded_list') // display list of related comments
-                    .targetEntity(nga.entity('comments'))
+                nga.field('backlinks', 'embedded_list') // display embedded list
                     .targetFields([
-                        nga.field('id'),
-                        nga.field('author.name'),
+                        nga.field('date', 'datetime')
+                            .template('<div class="row"><div class="col-lg-8"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'),
+                        nga.field('url')
+                    ])
+                    .sortField('date')
+                    .sortDir('DESC'),
+                nga.field('comments', 'referenced_list') // display list of related comments
+                    .targetEntity(nga.entity('comments'))
+                    .targetReferenceField('post_id')
+                    .targetFields([
+                        nga.field('id').isDetailLink(true),
                         nga.field('created_at').label('Posted'),
-                        nga.field('body', 'text').label('Comment')
+                        nga.field('body').label('Comment')
                     ])
                     .sortField('created_at')
                     .sortDir('DESC')
+                    .listActions(['edit']),
+                nga.field('').label('')
+                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm"></ma-filtered-list-button><ma-create-button entity-name="comments" size="sm" label="Create related comment" default-values="{ post_id: entry.values.id }"></ma-create-button></span>')
             ]);
 
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list
             .fields([
                 nga.field('id'),
-                post.creationView().fields(),
-                nga.field('category', 'choice')
-                    .choices([
+                nga.field('category', 'choice') // a choice field is rendered as a dropdown in the edition view
+                    .choices([ // List the choice as object literals
                         { label: 'Tech', value: 'tech' },
                         { label: 'Lifestyle', value: 'lifestyle' }
                     ]),
                 nga.field('subcategory', 'choice')
                     .choices(subCategories),
-                nga.field('tags', 'reference_many') // ReferenceMany translates to a list of labels
+                nga.field('tags', 'reference_many') // ReferenceMany translates to a select multiple
                     .targetEntity(tag)
                     .targetField(nga.field('name')),
                 nga.field('pictures', 'json'),
                 nga.field('views', 'number'),
                 nga.field('average_note', 'float'),
-                nga.field('comments', 'embedded_list') // display list of related comments
+                nga.field('backlinks', 'embedded_list') // display embedded list
+                    .targetFields([
+                        nga.field('date', 'datetime'),
+                        nga.field('url')
+                    ])
+                    .sortField('date')
+                    .sortDir('DESC'),
+                nga.field('comments', 'referenced_list') // display list of related comments
                     .targetEntity(nga.entity('comments'))
+                    .targetReferenceField('post_id')
                     .targetFields([
                         nga.field('id').isDetailLink(true),
-                        nga.field('author.name').label('Author'),
                         nga.field('created_at').label('Posted'),
                         nga.field('body').label('Comment')
                     ])
-                    .sortField('id')
+                    .sortField('created_at')
                     .sortDir('DESC')
                     .listActions(['edit']),
                 nga.field('').label('')

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -170,7 +170,32 @@
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list
             .fields([
                 nga.field('id'),
-                post.editionView().fields(), // reuse fields from another view in another order
+                post.creationView().fields(),
+                nga.field('category', 'choice')
+                    .choices([
+                        { label: 'Tech', value: 'tech' },
+                        { label: 'Lifestyle', value: 'lifestyle' }
+                    ]),
+                nga.field('subcategory', 'choice')
+                    .choices(subCategories),
+                nga.field('tags', 'reference_many') // ReferenceMany translates to a list of labels
+                    .targetEntity(tag)
+                    .targetField(nga.field('name')),
+                nga.field('pictures', 'json'),
+                nga.field('views', 'number'),
+                nga.field('average_note', 'float'),
+                nga.field('comments', 'embedded_list') // display list of related comments
+                    .targetEntity(nga.entity('comments'))
+                    .targetFields([
+                        nga.field('id').isDetailLink(true),
+                        nga.field('created_at').label('Posted'),
+                        nga.field('body').label('Comment')
+                    ])
+                    .sortField('id')
+                    .sortDir('DESC')
+                    .listActions(['edit']),
+                nga.field('').label('')
+                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm"></ma-filtered-list-button><ma-create-button entity-name="comments" size="sm" label="Create related comment" default-values="{ post_id: entry.values.id }"></ma-create-button></span>'),
                 nga.field('custom_action').label('')
                     .template('<send-email post="entry"></send-email>')
             ]);

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -152,19 +152,16 @@
                     .cssClasses('col-sm-4'),
                 nga.field('average_note', 'float')
                     .cssClasses('col-sm-4'),
-                nga.field('comments', 'referenced_list') // display list of related comments
+                nga.field('comments', 'embedded_list') // display list of related comments
                     .targetEntity(nga.entity('comments'))
-                    .targetReferenceField('post_id')
                     .targetFields([
-                        nga.field('id').isDetailLink(true),
+                        nga.field('id'),
+                        nga.field('author.name'),
                         nga.field('created_at').label('Posted'),
-                        nga.field('body').label('Comment')
+                        nga.field('body', 'text').label('Comment')
                     ])
                     .sortField('created_at')
                     .sortDir('DESC')
-                    .listActions(['edit']),
-                nga.field('').label('')
-                    .template('<span class="pull-right"><ma-filtered-list-button entity-name="comments" filter="{ post_id: entry.values.id }" size="sm"></ma-filtered-list-button><ma-create-button entity-name="comments" size="sm" label="Create related comment" default-values="{ post_id: entry.values.id }"></ma-create-button></span>')
             ]);
 
         post.showView() // a showView displays one entry in full page - allows to display more data than in a a list
@@ -188,6 +185,7 @@
                     .targetEntity(nga.entity('comments'))
                     .targetFields([
                         nga.field('id').isDetailLink(true),
+                        nga.field('author.name').label('Author'),
                         nga.field('created_at').label('Posted'),
                         nga.field('body').label('Comment')
                     ])

--- a/examples/blog/data.js
+++ b/examples/blog/data.js
@@ -35,12 +35,12 @@ var apiData = {
         }
       },
       "published_at": "2012-08-06",
-      "tags": [
-        1,
-        3
-      ],
+      "tags": [1, 3],
       "category": "tech",
-      "subcategory": "computers"
+      "subcategory": "computers",
+      "backlinks": [
+        { "date": "2012-08-09T00:00:00.000Z", "url": "http://example.com/bar/baz.html" },
+      ]
     },
     {
       "id": 2,
@@ -50,10 +50,8 @@ var apiData = {
       "views": 563,
       "average_note": 3.48121,
       "published_at": "2012-08-08",
-      "tags": [
-        3,
-        5
-      ]
+      "tags": [3, 5],
+      "backlinks": []
     },
     {
       "id": 3,
@@ -63,9 +61,12 @@ var apiData = {
       "views": 467,
       "average_note": 4.12319,
       "published_at": "2012-08-08",
-      "tags": [
-        1,
-        2
+      "tags": [1,2],
+      "backlinks": [
+        { "date": "2012-08-10T00:00:00.000Z", "url": "http://example.com/foo/bar.html" },
+        { "date": "2012-08-14T00:00:00.000Z", "url": "https://blog.johndoe.com/2012/08/12/foobar.html" },
+        { "date": "2012-08-22T00:00:00.000Z", "url": "https://foo.bar.com/lorem/ipsum" },
+        { "date": "2012-08-29T00:00:00.000Z", "url": "http://dicta.es/nam_doloremque" }
       ]
     },
     {
@@ -164,7 +165,10 @@ var apiData = {
       ],
       "category": "tech",
       "subcategory": "computers",
-      "pictures": null
+      "pictures": null,
+      "backlinks": [
+        { "date": "2012-10-29T00:00:00.000Z", "url": "http://dicta.es/similique_pariatur" }
+      ]
     },
     {
       "id": 12,
@@ -177,7 +181,11 @@ var apiData = {
       "tags": [],
       "category": "lifestyle",
       "subcategory": "fitness",
-      "pictures": null
+      "pictures": { "first": {}, "second": {} },
+      "backlinks": [
+        { "date": "2012-08-07T00:00:00.000Z", "url": "http://example.com/foo/bar.html" },
+        { "date": "2012-08-12T00:00:00.000Z", "url": "https://blog.johndoe.com/2012/08/12/foobar.html" }
+      ]
     }
   ],
   "comments": [

--- a/examples/blog/fakerest-init.js
+++ b/examples/blog/fakerest-init.js
@@ -5,6 +5,10 @@
     var restServer = new FakeRest.Server('http://localhost:3000');
     var testEnv = window.location.pathname.indexOf('test.html') !== -1;
     restServer.init(apiData);
+    restServer.setDefaultQuery(function(resourceName) {
+        if (resourceName == 'posts') return { embed: ['comments'] }
+        return {};
+    });
     restServer.toggleLogging(); // logging is off by default, enable it
 
     // use sinon.js to monkey-patch XmlHttpRequest

--- a/examples/blog/index.html
+++ b/examples/blog/index.html
@@ -5,6 +5,11 @@
         <title>Angular admin</title>
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" href="http://localhost:8000/build/ng-admin.min.css">
+        <style type="text/css">
+            .ng-admin-entity-posts .ng-admin-column-title {
+                max-width: 250px;
+            }
+        </style>
     </head>
     <body ng-app="myApp" ng-strict-di>
         <div ui-view></div>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.5.0",
+    "admin-config": "^0.5.1",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.4.0",
+    "admin-config": "^0.5.0",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",
@@ -29,7 +29,7 @@
     "es6-promise": "^2.3.0",
     "exports-loader": "^0.6.2",
     "extract-text-webpack-plugin": "^0.8.0",
-    "fakerest": "^1.0.10",
+    "fakerest": "^1.1.4",
     "file-loader": "^0.8.1",
     "font-awesome": "^4.3.0",
     "grunt": "~0.4.4",

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -27,6 +27,7 @@ CrudModule.directive('maButtonField', require('./field/maButtonField'));
 CrudModule.directive('maChoiceField', require('./field/maChoiceField'));
 CrudModule.directive('maChoicesField', require('./field/maChoicesField'));
 CrudModule.directive('maDateField', require('./field/maDateField'));
+CrudModule.directive('maEmbeddedListField', require('./field/maEmbeddedListField'));
 CrudModule.directive('maInputField', require('./field/maInputField'));
 CrudModule.directive('maJsonField', require('./field/maJsonField'));
 CrudModule.directive('maFileField', require('./field/maFileField'));

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -54,6 +54,7 @@ CrudModule.directive('maColumn', require('./column/maColumn'));
 CrudModule.directive('maBooleanColumn', require('./column/maBooleanColumn'));
 CrudModule.directive('maChoicesColumn', require('./column/maChoicesColumn'));
 CrudModule.directive('maDateColumn', require('./column/maDateColumn'));
+CrudModule.directive('maEmbeddedListColumn', require('./column/maEmbeddedListColumn'));
 CrudModule.directive('maJsonColumn', require('./column/maJsonColumn'));
 CrudModule.directive('maNumberColumn', require('./column/maNumberColumn'));
 CrudModule.directive('maReferenceColumn', require('./column/maReferenceColumn'));

--- a/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
@@ -1,0 +1,52 @@
+import Entry from 'admin-config/lib/Entry';
+
+function maEmbeddedListColumn(NgAdminConfiguration) {
+    return {
+        scope: {
+            'field': '&',
+            'value': '&'
+        },
+        restrict: 'E',
+        link: {
+            pre: function(scope) {
+                const field = scope.field();
+                const targetEntity = field.targetEntity();
+                const targetEntityName = targetEntity.name();
+                const targetFields = field.targetFields();
+                const sortField = field.sortField();
+                const sortDir = field.sortDir() === 'DESC' ? -1 : 1;
+                var filterFunc;
+                if (field.permanentFilters()) {
+                    const filters = field.permanentFilters();
+                    const filterKeys = Object.keys(filters);
+                    filterFunc = (entry) => {
+                        return filterKeys.reduce((isFiltered, key) => isFiltered && entry.values[key] == filters[key], true)
+                    }
+                } else {
+                    filterFunc = () => true;
+                }
+                const entries = Entry
+                    .createArrayFromRest(scope.value(), targetFields, targetEntityName, targetEntity.identifier().name())
+                    .sort((entry1, entry2) => sortDir * (entry1.values[sortField] - entry2.values[sortField]))
+                    .filter(filterFunc);
+                scope.field = field;
+                scope.targetFields = targetFields;
+                scope.entries = entries;
+                scope.entity = targetEntityName ? NgAdminConfiguration().getEntity(targetEntityName) : targetEntity;
+            }
+        },
+        template: `
+<ma-datagrid name="{{ field.datagridName() }}"
+    entries="::entries"
+    fields="::targetFields"
+    list-actions="::field.listActions()"
+    entity="::entity"
+    datastore="::datastore()">
+</ma-datagrid>`
+    };
+}
+
+maEmbeddedListColumn.$inject = ['NgAdminConfiguration'];
+
+module.exports = maEmbeddedListColumn;
+

--- a/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
@@ -26,10 +26,22 @@ function maEmbeddedListColumn(NgAdminConfiguration) {
                 } else {
                     filterFunc = () => true;
                 }
-                const entries = Entry
-                    .createArrayFromRest(scope.value(), targetFields, targetEntityName, targetEntity.identifier().name())
-                    .sort((entry1, entry2) => sortDir * (entry1.values[sortField] - entry2.values[sortField]))
+                let entries = Entry
+                    .createArrayFromRest(scope.value() || [], targetFields, targetEntityName, targetEntity.identifier().name())
+                    .sort((entry1, entry2) => {
+                        // use < and > instead of substraction to sort strings properly
+                        if (entry1.values[sortField] > entry2.values[sortField]) return sortDir;
+                        if (entry1.values[sortField] < entry2.values[sortField]) return -1 * sortDir;
+                        return 0;
+                    })
                     .filter(filterFunc);
+                if (!targetEntityName) {
+                    let index = 0;
+                    entries = entries.map(e => {
+                        e._identifierValue = index++;
+                        return e;
+                    });
+                };
                 scope.field = field;
                 scope.targetFields = targetFields;
                 scope.entries = entries;
@@ -37,7 +49,7 @@ function maEmbeddedListColumn(NgAdminConfiguration) {
             }
         },
         template: `
-<ma-datagrid name="{{ field.datagridName() }}"
+<ma-datagrid ng-if="::entries.length > 0" name="{{ field.datagridName() }}"
     entries="::entries"
     fields="::targetFields"
     list-actions="::field.listActions()"

--- a/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maEmbeddedListColumn.js
@@ -4,7 +4,8 @@ function maEmbeddedListColumn(NgAdminConfiguration) {
     return {
         scope: {
             'field': '&',
-            'value': '&'
+            'value': '&',
+            'datastore': '&'
         },
         restrict: 'E',
         link: {

--- a/src/javascripts/ng-admin/Crud/column/maReferencedListColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maReferencedListColumn.js
@@ -14,7 +14,7 @@ function maReferencedListColumn(NgAdminConfiguration) {
             }
         },
         template: `
-<ma-datagrid name="{{ field.datagridName() }}"
+<ma-datagrid ng-if="::entries.length > 0" name="{{ field.datagridName() }}"
     entries="::entries"
     fields="::field.targetFields()"
     list-actions="::field.listActions()"

--- a/src/javascripts/ng-admin/Crud/config/factories.js
+++ b/src/javascripts/ng-admin/Crud/config/factories.js
@@ -5,6 +5,7 @@ function factories(fvp) {
     fvp.registerFieldView('date', require('../fieldView/DateFieldView'));
     fvp.registerFieldView('datetime', require('../fieldView/DateTimeFieldView'));
     fvp.registerFieldView('email', require('../fieldView/EmailFieldView'));
+    fvp.registerFieldView('embedded_list', require('../fieldView/EmbeddedListFieldView'));
     fvp.registerFieldView('file', require('../fieldView/FileFieldView'));
     fvp.registerFieldView('float', require('../fieldView/FloatFieldView'));
     fvp.registerFieldView('json', require('../fieldView/JsonFieldView'));

--- a/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
+++ b/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
@@ -21,8 +21,8 @@ function maEmbeddedListField() {
                     const filters = field.permanentFilters();
                     const filterKeys = Object.keys(filters);
                     filterFunc = (entry) => {
-                        return filterKeys.reduce((isFiltered, key) => isFiltered && entry.values[key] == filters[key], true)
-                    }
+                        return filterKeys.reduce((isFiltered, key) => isFiltered && entry.values[key] === filters[key], true);
+                    };
                 } else {
                     filterFunc = () => true;
                 }
@@ -42,7 +42,7 @@ function maEmbeddedListField() {
                 };
                 scope.$watch('entries', (newEntries, oldEntries) => {
                     if (newEntries === oldEntries) return;
-                    scope.value = newEntries.map(e => e.transformToRest(targetFields))
+                    scope.value = newEntries.map(e => e.transformToRest(targetFields));
                 }, true);
             }
         },
@@ -69,4 +69,3 @@ function maEmbeddedListField() {
 maEmbeddedListField.$inject = [];
 
 module.exports = maEmbeddedListField;
-

--- a/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
+++ b/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
@@ -47,9 +47,9 @@ function maEmbeddedListField() {
             }
         },
         template: `
-<div class="row">
+<div class="row"><div class="col-sm-12">
     <ng-form ng-repeat="entry in entries track by $index" class="subentry" name="subform_{{$index}}" ng-init="formName = 'subform_' + $index">
-        <div class="pull-right">
+        <div class="remove_button_container">
                 <a class="btn btn-default btn-sm" ng-click="remove(entry)"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>&nbsp;Remove</a>
         </div>
         <div class="form-field form-group" ng-repeat="field in ::fields track by $index">
@@ -62,7 +62,7 @@ function maEmbeddedListField() {
             <a class="btn btn-default btn-sm" ng-click="addNew()"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>&nbsp;Add new {{ field().name() }}</a>
         </div>
     </div>
-</div>`
+</div></div>`
     };
 }
 

--- a/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
+++ b/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
@@ -28,10 +28,15 @@ function maEmbeddedListField() {
                 }
                 scope.fields = targetFields;
                 scope.entries = Entry
-                    .createArrayFromRest(scope.value, targetFields, targetEntityName, targetEntity.identifier().name())
-                    .sort((entry1, entry2) => sortDir * (entry1.values[sortField] - entry2.values[sortField]))
+                    .createArrayFromRest(scope.value || [], targetFields, targetEntityName, targetEntity.identifier().name())
+                    .sort((entry1, entry2) => {
+                        // use < and > instead of substraction to sort strings properly
+                        if (entry1.values[sortField] > entry2.values[sortField]) return sortDir;
+                        if (entry1.values[sortField] < entry2.values[sortField]) return -1 * sortDir;
+                        return 0;
+                    })
                     .filter(filterFunc);
-                scope.addNew = () => scope.entries.unshift(Entry.createForFields(targetFields));
+                scope.addNew = () => scope.entries.push(Entry.createForFields(targetFields));
                 scope.remove = entry => {
                     scope.entries = scope.entries.filter(e => e !== entry);
                 };

--- a/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
+++ b/src/javascripts/ng-admin/Crud/field/maEmbeddedListField.js
@@ -1,0 +1,67 @@
+import Entry from 'admin-config/lib/Entry';
+
+function maEmbeddedListField() {
+    return {
+        scope: {
+            'field': '&',
+            'value': '=',
+            'datastore': '&'
+        },
+        restrict: 'E',
+        link: {
+            pre: function(scope) {
+                const field = scope.field();
+                const targetEntity = field.targetEntity();
+                const targetEntityName = targetEntity.name();
+                const targetFields = field.targetFields();
+                const sortField = field.sortField();
+                const sortDir = field.sortDir() === 'DESC' ? -1 : 1;
+                var filterFunc;
+                if (field.permanentFilters()) {
+                    const filters = field.permanentFilters();
+                    const filterKeys = Object.keys(filters);
+                    filterFunc = (entry) => {
+                        return filterKeys.reduce((isFiltered, key) => isFiltered && entry.values[key] == filters[key], true)
+                    }
+                } else {
+                    filterFunc = () => true;
+                }
+                scope.fields = targetFields;
+                scope.entries = Entry
+                    .createArrayFromRest(scope.value, targetFields, targetEntityName, targetEntity.identifier().name())
+                    .sort((entry1, entry2) => sortDir * (entry1.values[sortField] - entry2.values[sortField]))
+                    .filter(filterFunc);
+                scope.addNew = () => scope.entries.unshift(Entry.createForFields(targetFields));
+                scope.remove = entry => {
+                    scope.entries = scope.entries.filter(e => e !== entry);
+                };
+                scope.$watch('entries', (newEntries, oldEntries) => {
+                    if (newEntries === oldEntries) return;
+                    scope.value = newEntries.map(e => e.transformToRest(targetFields))
+                }, true);
+            }
+        },
+        template: `
+<div class="row">
+    <ng-form ng-repeat="entry in entries track by $index" class="subentry" name="subform_{{$index}}" ng-init="formName = 'subform_' + $index">
+        <div class="pull-right">
+                <a class="btn btn-default btn-sm" ng-click="remove(entry)"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>&nbsp;Remove</a>
+        </div>
+        <div class="form-field form-group" ng-repeat="field in ::fields track by $index">
+            <ma-field field="::field" value="entry.values[field.name()]" entry="entry" entity="::entity" form="formName" datastore="::datastore()"></ma-field>
+        </div>
+        <hr/>
+    </ng-form>
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <a class="btn btn-default btn-sm" ng-click="addNew()"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>&nbsp;Add new {{ field().name() }}</a>
+        </div>
+    </div>
+</div>`
+    };
+}
+
+maEmbeddedListField.$inject = [];
+
+module.exports = maEmbeddedListField;
+

--- a/src/javascripts/ng-admin/Crud/fieldView/DateFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/DateFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => '<ma-date-column field="::field" value="::value"></ma-date-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
     getFilterWidget: () => '<ma-date-field field="::field" value="value"></ma-date-field>',
-    getWriteWidget:  () => '<div class="row"><div class="col-sm-5 col-lg-4"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'
+    getWriteWidget:  () => '<div class="date_widget"><ma-date-field field="::field" value="value"></ma-date-field></div>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/DateTimeFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/DateTimeFieldView.js
@@ -2,5 +2,5 @@ module.exports = {
     getReadWidget:   () => '<ma-date-column field="::field" value="::value"></ma-date-column>',
     getLinkWidget:   () => '<a ng-click="gotoDetail()">' + module.exports.getReadWidget() + '</a>',
     getFilterWidget: () => '<ma-date-field field="::field" value="value"></ma-date-field>',
-    getWriteWidget:  () => '<div class="row"><div class="col-sm-7 col-lg-6"><ma-date-field field="::field" value="value"></ma-date-field></div></div>'
+    getWriteWidget:  () => '<div class="datetime_widget"><ma-date-field field="::field" value="value"></ma-date-field></div>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/EmbeddedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/EmbeddedListFieldView.js
@@ -1,6 +1,6 @@
 module.exports = {
-    getReadWidget:   () => '<ma-embedded-list-column field="::field" value="::value"></ma-embedded-list-column>',
+    getReadWidget:   () => '<ma-embedded-list-column field="::field" value="::value" datastore="::datastore"></ma-embedded-list-column>',
     getLinkWidget:   () => 'error: cannot display referenced_list field as linkable',
     getFilterWidget: () => 'error: cannot display referenced_list field as filter',
-    getWriteWidget:  () => 'error: cannot display referenced_list field as editable'
+    getWriteWidget:  () => '<ma-embedded-list-field field="::field" value="value" datastore="::datastore"></ma-embedded-list-field>'
 };

--- a/src/javascripts/ng-admin/Crud/fieldView/EmbeddedListFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/EmbeddedListFieldView.js
@@ -1,0 +1,6 @@
+module.exports = {
+    getReadWidget:   () => '<ma-embedded-list-column field="::field" value="::value"></ma-embedded-list-column>',
+    getLinkWidget:   () => 'error: cannot display referenced_list field as linkable',
+    getFilterWidget: () => 'error: cannot display referenced_list field as filter',
+    getWriteWidget:  () => 'error: cannot display referenced_list field as editable'
+};

--- a/src/javascripts/ng-admin/Crud/list/maDatagrid.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagrid.js
@@ -15,7 +15,10 @@ define(function (require) {
                 fields: '&',
                 listActions: '&',
                 entity: '&',
-                datastore: '&'
+                datastore: '&',
+                sortField: '@',
+                sortDir: '@',
+                sort: '&'
             },
             controllerAs: 'datagrid',
             controller: maDatagridController,
@@ -27,7 +30,7 @@ define(function (require) {
                 <ma-datagrid-multi-selector toggle-select-all="toggleSelectAll()" selection="selection" entries="entries"/>
             </th>
             <th ng-repeat="field in fields() track by $index" ng-class="field.getCssClasses()" class="ng-admin-column-{{ ::field.name() }} ng-admin-type-{{ ::field.type() }}">
-                <a ng-click="datagrid.sort(field)">
+                <a ng-click="datagrid.sortCallback(field)">
                     <span class="glyphicon {{ datagrid.sortDir === 'DESC' ? 'glyphicon-chevron-down': 'glyphicon-chevron-up' }}" ng-if="datagrid.isSorting(field)"></span>
 
                     {{ field.label() }}

--- a/src/javascripts/ng-admin/Crud/list/maDatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridController.js
@@ -12,7 +12,7 @@ define(function () {
      *
      * @constructor
      */
-    function DatagridController($scope, $location, $stateParams, $anchorScroll) {
+    function DatagridController($scope, $location, $stateParams, $anchorScroll, $attrs) {
         $scope.entity = $scope.entity();
         this.$scope = $scope;
         this.$location = $location;
@@ -20,12 +20,15 @@ define(function () {
         this.datastore = this.$scope.datastore();
         this.filters = {};
         this.shouldDisplayActions = this.$scope.listActions() && this.$scope.listActions().length > 0;
-
         $scope.toggleSelect = this.toggleSelect.bind(this);
         $scope.toggleSelectAll = this.toggleSelectAll.bind(this);
-
-        this.sortField = 'sortField' in $stateParams ? $stateParams.sortField : null;
-        this.sortDir = 'sortDir' in $stateParams ? $stateParams.sortDir : null;
+        $scope.sortField = $attrs.sortField;
+        $scope.sortDir = $attrs.sortDir;
+        this.sortField = 'sortField' in $stateParams ? $stateParams.sortField : $attrs.sortField;
+        this.sortDir = 'sortDir' in $stateParams ? $stateParams.sortDir : $attrs.sortDir;
+        $attrs.$observe('sortDir', sortDir => this.sortDir = sortDir);
+        $attrs.$observe('sortField', sortField => this.sortField = sortField);
+        this.sortCallback = $scope.sort() ? $scope.sort() : this.sort.bind(this);
     }
 
     /**
@@ -73,7 +76,7 @@ define(function () {
      * @returns {String}
      */
     DatagridController.prototype.getSortName = function (field) {
-        return this.$scope.name + '.' + field.name();
+        return this.$scope.name ? this.$scope.name + '.' + field.name() : field.name();
     };
 
     DatagridController.prototype.toggleSelect = function (entry) {
@@ -99,7 +102,7 @@ define(function () {
         this.$scope.selection = [];
     };
 
-    DatagridController.$inject = ['$scope', '$location', '$stateParams', '$anchorScroll'];
+    DatagridController.$inject = ['$scope', '$location', '$stateParams', '$anchorScroll', '$attrs'];
 
     return DatagridController;
 });

--- a/src/javascripts/test/e2e/EditionViewSpec.js
+++ b/src/javascripts/test/e2e/EditionViewSpec.js
@@ -80,6 +80,25 @@ describe('EditionView', function () {
         });
     })
 
+    describe('EmbeddedListField', function() {
+        beforeEach(function() {
+            browser.get(browser.baseUrl + '#/posts/edit/1');
+        });
+
+        it('should render as a list of subforms', function () {
+            $$('.ng-admin-field-backlinks ng-form')
+            .then(function subFormsExist(subforms) {
+                expect(subforms.length).toBe(1);
+            })
+            .then(function getUrlInput() {
+                return $$('.ng-admin-field-backlinks ng-form input#url').first();
+            })
+            .then(function urlInputContainsUrl(input) {
+                expect(input.getAttribute('value')).toBe('http://example.com/bar/baz.html');
+            });
+        });
+    })
+
     describe('DetailLink', function() {
         beforeEach(function() {
             browser.get(browser.baseUrl + '#/posts/edit/1');

--- a/src/javascripts/test/e2e/ShowViewSpec.js
+++ b/src/javascripts/test/e2e/ShowViewSpec.js
@@ -25,12 +25,34 @@ describe('ShowView', function () {
 
     describe('ReferencedListField', function() {
         it('should render as a datagrid', function () {
-            $$('.ng-admin-field-comments th').then(function (inputs) {
+            $$('.ng-admin-field-comments th')
+            .then(function (inputs) {
                 expect(inputs.length).toBe(4);
-
                 expect(inputs[0].getAttribute('class')).toBe('ng-admin-column-id ng-admin-type-string');
                 expect(inputs[1].getAttribute('class')).toBe('ng-admin-column-created_at ng-admin-type-string');
                 expect(inputs[2].getAttribute('class')).toBe('ng-admin-column-body ng-admin-type-string');
+            })
+            .then(function() {
+                return $$('.ng-admin-field-comments tbody tr');
+            })
+            .then(function (lines) {
+                expect(lines.length).toBe(2);
+            });
+        });
+    });
+
+    describe('EmbeddedListField', function() {
+        it('should render as a datagrid', function () {
+            $$('.ng-admin-field-backlinks th').then(function (inputs) {
+                expect(inputs.length).toBe(2);
+                expect(inputs[0].getAttribute('class')).toBe('ng-admin-column-date ng-admin-type-datetime');
+                expect(inputs[1].getAttribute('class')).toBe('ng-admin-column-url ng-admin-type-string');
+            })
+            .then(function() {
+                return $$('.ng-admin-field-backlinks tbody tr');
+            })
+            .then(function (lines) {
+                expect(lines.length).toBe(1);
             });
         });
     });

--- a/src/javascripts/test/unit/Crud/column/maEmbeddedListColumnSpec.js
+++ b/src/javascripts/test/unit/Crud/column/maEmbeddedListColumnSpec.js
@@ -28,7 +28,7 @@ describe('directive: ma-embedded-list-column', function () {
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.children()[0].nodeName).toBe('MA-DATAGRID');
-        const datagridScope = angular.element(element.children()[0]).scope();
+        const datagridScope = element.children().eq(0).scope();
         expect(datagridScope.entries.length).toBe(2);
         expect(datagridScope.entries[0].values).toEqual({ num: 1, name: 'foo', dummy: 0 });
         expect(datagridScope.entries[1].values).toEqual({ num: 2, name: 'bar', dummy: 1 });

--- a/src/javascripts/test/unit/Crud/column/maEmbeddedListColumnSpec.js
+++ b/src/javascripts/test/unit/Crud/column/maEmbeddedListColumnSpec.js
@@ -1,0 +1,68 @@
+/*global angular,inject,describe,it,expect,beforeEach*/
+describe('directive: ma-embedded-list-column', function () {
+    'use strict';
+
+    var directive = require('../../../../ng-admin/Crud/column/maEmbeddedListColumn');
+    var Field = require('admin-config/lib/Field/Field');
+    var EmbeddedListField = require('admin-config/lib/Field/EmbeddedListField');
+
+    angular.module('testapp_EmbeddedListColumn', [])
+        .directive('maEmbeddedListColumn', directive)
+        .service('NgAdminConfiguration', () => () => ({}));
+
+    var $compile,
+        scope,
+        directiveUsage = '<ma-embedded-list-column field="field" value="value" datastore="datastore"></ma-embedded-list-column>';
+
+    beforeEach(angular.mock.module('testapp_EmbeddedListColumn'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    it('should contain a datagrid', function () {
+        scope.field = new EmbeddedListField()
+            .targetFields([new Field('num'), new Field('name')]);
+        scope.value = [{ num: 1, name: 'foo', dummy: 0 }, { num: 2, name: 'bar', dummy: 1 }];
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.children()[0].nodeName).toBe('MA-DATAGRID');
+        const datagridScope = angular.element(element.children()[0]).scope();
+        expect(datagridScope.entries.length).toBe(2);
+        expect(datagridScope.entries[0].values).toEqual({ num: 1, name: 'foo', dummy: 0 });
+        expect(datagridScope.entries[1].values).toEqual({ num: 2, name: 'bar', dummy: 1 });
+        expect(datagridScope.targetFields.length).toBe(2);
+        expect(datagridScope.targetFields[0].name()).toBe('num');
+        expect(datagridScope.targetFields[1].name()).toBe('name');
+    });
+
+    it('should sort the list according to the sortField', function () {
+        scope.field = new EmbeddedListField()
+            .targetFields([new Field('num'), new Field('name')])
+            .sortField('num')
+            .sortDir('DESC');
+        scope.value = [{ num: 1, name: 'foo', dummy: 0 }, { num: 2, name: 'bar', dummy: 1 }];
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        const datagridScope = angular.element(element.children()[0]).scope();
+        expect(datagridScope.entries.length).toBe(2);
+        expect(datagridScope.entries[0].values).toEqual({ num: 2, name: 'bar', dummy: 1 });
+        expect(datagridScope.entries[1].values).toEqual({ num: 1, name: 'foo', dummy: 0 });
+        expect(datagridScope.sortField).toEqual('num');
+        expect(datagridScope.sortDir).toEqual('DESC');
+    });
+
+    it('should filter the list according to the permanentFilters', function () {
+        scope.field = new EmbeddedListField()
+            .targetFields([new Field('num'), new Field('name')])
+            .permanentFilters({ name: 'foo' });
+        scope.value = [{ num: 1, name: 'foo', dummy: 0 }, { num: 2, name: 'bar', dummy: 1 }];
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        const datagridScope = angular.element(element.children()[0]).scope();
+        expect(datagridScope.entries.length).toBe(1);
+        expect(datagridScope.entries[0].values).toEqual({ num: 1, name: 'foo', dummy: 0 });
+    });
+
+});

--- a/src/javascripts/test/unit/Crud/field/maEmbeddedListFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maEmbeddedListFieldSpec.js
@@ -1,0 +1,45 @@
+/*global angular,inject,describe,it,expect,beforeEach*/
+describe('directive: ma-embedded-list-field', function () {
+    'use strict';
+
+    var directive = require('../../../../ng-admin/Crud/field/maEmbeddedListField');
+    var Field = require('admin-config/lib/Field/Field');
+    var EmbeddedListField = require('admin-config/lib/Field/EmbeddedListField');
+
+    angular.module('testapp_EmbeddedListField', [])
+        .directive('maEmbeddedListField', directive)
+        .directive('maField', function() {
+            return {
+                scope: { value: '=' },
+                template: '<input ng-model="value"></input>'
+            };
+        });
+
+    var $compile,
+        scope,
+        directiveUsage = '<ma-embedded-list-field field="field" value="value" datastore="datastore"></ma-embedded-list-field>';
+
+    beforeEach(angular.mock.module('testapp_EmbeddedListField'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    it('should contain a list of subforms with bounded inputs', function () {
+        scope.field = new EmbeddedListField('dummy')
+            .targetFields([new Field('num'), new Field('name')]);
+        scope.value = [{ num: 1, name: 'foo', dummy: 0 }, { num: 2, name: 'bar', dummy: 1 }];
+        var element = $compile(directiveUsage)(scope);
+        scope.$digest();
+        expect(element.find('ng-form').length).toBe(2);
+        expect(element.find('input').length).toBe(4);
+        expect(element.find('a').eq(0).text().trim()).toBe('Remove');
+        expect(element.find('input').eq(0).scope().value).toBe(1);
+        expect(element.find('input').eq(1).scope().value).toBe('foo');
+        expect(element.find('a').eq(1).text().trim()).toBe('Remove');
+        expect(element.find('input').eq(2).scope().value).toBe(2);
+        expect(element.find('input').eq(3).scope().value).toBe('bar');
+        expect(element.find('a').eq(2).text().trim()).toBe('Add new dummy');
+    });
+});

--- a/src/javascripts/test/unit/Crud/list/DatagridControllerSpec.js
+++ b/src/javascripts/test/unit/Crud/list/DatagridControllerSpec.js
@@ -18,12 +18,13 @@ describe('controller: ma-datagrid', function () {
             entity: () => new Entity('my_entity'),
             entries: entries,
             selection: [],
-            datastore: () => { return {}; }
+            datastore: () => { return {}; },
+            sort: () => null
         }, {
             search: () => {
                 return {};
             }
-        }, {});
+        }, {}, {}, { $observe: () => null });
     });
 
     describe('toggleSelect', function () {

--- a/src/sass/ng-admin.scss
+++ b/src/sass/ng-admin.scss
@@ -240,6 +240,29 @@ div.bottom-loader {
         width: 100%;
     }
 
+    .date_widget {
+        width: 10em;
+        @media (max-width: 768px) {
+            width: 100%
+        }
+    }
+
+    .datetime_widget {
+        width: 15em;
+        @media (max-width: 768px) {
+            width: 100%
+        }
+    }
+
+    .remove_button_container {
+        float: right;
+        @media (max-width: 992px) {
+            float: none;
+            display: block;
+            text-align: right;
+        }
+    }
+
     .ta-toolbar button {
         font-size: 12px;
         padding: 5px 8px;

--- a/src/sass/ng-admin.scss
+++ b/src/sass/ng-admin.scss
@@ -270,6 +270,12 @@ div.bottom-loader {
                 }
             }
         }
+
+        .ng-admin-type-embedded_list, .ng-admin-type-referenced_list {
+            .table-condensed > thead > tr > th {
+                padding-top: 0;
+            }
+        }
     }
 
     .CodeMirror {
@@ -277,3 +283,4 @@ div.bottom-loader {
         border-radius: 4px;
     }
 }
+


### PR DESCRIPTION
The new `embedded_list` type maps an array of objects inside an entry, e.g.

```json
{  
   "id":1,
   "title":"Accusantium qui nihil voluptatum quia voluptas maxime ab similique",
   "comments":[  
      {  
         "author":{  
            "name":"Edmond Schulist"
         },
         "body":"I ought to tell me your history, you know,' the Hatter and the happy summer days. THE.",
         "created_at":"2012-08-07"
      },
      {  
         "author":{  
            "name":"Logan Schowalter"
         },
         "body":"I don't want to be?' it asked. 'Oh, I'm not Ada,' she said, 'and see whether it's marked \"poison\" or not'; for she had asked it aloud; and in despair she put her hand on the end of the.",
         "created_at":"2012-08-05"
      }
   ]
}
```

You can now map the `comments` field:

```js
posts.showView().fields([
    nga.field('id'),
    nga.field('title'),
    nga.field('comments', 'embedded_list')
        .targetEntity(nga.entity('comments'))
        .targetFields([
            nga.field('id').isDetailLink(true),
            nga.field('author.name').label('Author'),
            nga.field('created_at').label('Posted'),
            nga.field('body').label('Comment')
        ])
        .listActions(['edit'])
]);
```

This will display in the show view as a datagrid, exactly like `referenced_list`.

![image](https://cloud.githubusercontent.com/assets/99944/10244200/fccd4ee4-68fd-11e5-8e95-6fbd18decd7a.png)

And in an editionView like nested forms:

![image](https://cloud.githubusercontent.com/assets/99944/10248275/b6a894c0-691e-11e5-9bc8-52429ba269d2.png)

Of course, embedded entries don't require an entity. If they only live inside another entry, simply don't set the `targetEntity`. In that case, there can be no `detailLink` or default `listActions`, as there is no `Entity` to link to.

```js
posts.showView().fields([
    nga.field('id'),
    nga.field('title'),
    nga.field('comments', 'embedded_list')
        .targetFields([
            nga.field('author.name').label('Author'),
            nga.field('created_at').label('Posted'),
            nga.field('body').label('Comment')
        ])
]);
```

`embedded_list` fields support sorting and filtering:

```js
posts.showView().fields([
    nga.field('id'),
    nga.field('title'),
    nga.field('comments', 'embedded_list')
        .targetEntity(nga.entity('comments'))
        .targetFields([
            nga.field('id').isDetailLink(true),
            nga.field('author.name').label('Author'),
            nga.field('created_at').label('Posted'),
            nga.field('body').label('Comment')
        ])
        .sortField('id')
        .sortDir('DESC')
        .permanentFilters({
             published: true
        })
        .listActions(['edit'])
]);
```

This is a long-requested feature, and it should fix numerous issues (#241, #308, #627, #666)

- [x] implement read widget using dataGrid
- [x] implement write widget using embedded forms
- [x] add tests
- [x] add doc