### PR TITLE
[RFR] Remove duplicate API calls for filters, creation and edition view + fix reference field when empty

### DIFF
--- a/doc/Configuration-reference.md
+++ b/doc/Configuration-reference.md
@@ -658,18 +658,18 @@ If set to false, all references (in the limit of `perPage` parameter) would be r
     * `refreshDelay`: minimal delay between two API calls in milliseconds. By default: 500.
     * `searchQuery`: a function returning the parameters to add to the query string basd on the input string.
 
-        comments.editionView().fields([
-            nga.field('id'),
-            nga.field('post_id', 'reference')
-                .targetEntity(post)
-                .targetField(nga.field('title'))
-                .remoteComplete(true, {
-                    refreshDelay: 300,
-                    // populate choices from the response of GET /posts?q=XXX
-                    searchQuery: function(search) { return { q: search }; }
-                })
-                .perPage(10) // limit the number of results to 10
-        ]);
+            comments.editionView().fields([
+                nga.field('id'),
+                nga.field('post_id', 'reference')
+                    .targetEntity(post)
+                    .targetField(nga.field('title'))
+                    .remoteComplete(true, {
+                        refreshDelay: 300,
+                        // populate choices from the response of GET /posts?q=XXX
+                        searchQuery: function(search) { return { q: search }; }
+                    })
+                    .perPage(10) // limit the number of results to 10
+            ]);
 
 * `permanentFilters({ field1: value, field2: value, ...})`
 Add filters to the referenced results list. This can be very useful to restrict the list of possible values displayed in a dropdown list:
@@ -745,12 +745,14 @@ Define the field name used to link the referenced entity.
 Define a function that returns parameters for filtering API calls. You can use it if you API support filter for multiple values.
 
         // Will call /tags?tag_id[]=1&tag_id[]=2&tag_id%[]=5...
-        postList.fields([
+        post.listView().fields([
             nga.field('tags', 'reference_many')
                 .singleApiCall(function (tagIds) {
                     return { 'tag_id[]': tagIds };
                 })
         ]);
+
+    **Tip**: It also works for creationView and editionView
 
 * `permanentFilters({ field1: value, field2: value, ...})`
 Add filters to the referenced results list.
@@ -770,17 +772,17 @@ If set to false, all references (in the limit of `perPage` parameter) would be r
     Available options are:
 
     * `refreshDelay`: minimal delay between two API calls in milliseconds. By default: 500.
-    * `searchQuery`: a function returning the parameters to add to the query string basd on the input string.
+    * `searchQuery`: a function returning the parameters to add to the query string based on the input string.
 
-        post.editionView().fields([
-            nga.field('id'),
-            nga.field('tags', 'reference_many')
-                .targetEntity(tag)
-                .targetField(nga.field('name'))
-                .remoteComplete(true, {
-                    refreshDelay: 300,
-                    // populate choices from the response of GET /tags?q=XXX
-                    searchQuery: function(search) { return { q: search }; }
-                })
-                .perPage(10) // limit the number of results to 10
-        ]);
+            post.editionView().fields([
+                nga.field('id'),
+                nga.field('tags', 'reference_many')
+                    .targetEntity(tag)
+                    .targetField(nga.field('name'))
+                    .remoteComplete(true, {
+                        refreshDelay: 300,
+                        // populate choices from the response of GET /tags?q=XXX
+                        searchQuery: function(search) { return { q: search }; }
+                    })
+                    .perPage(10) // limit the number of results to 10
+            ]);

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -119,7 +119,17 @@
                     .validation({ required: true, minlength: 3, maxlength: 100 }), // add validation rules for fields
                 nga.field('teaser', 'text'), // text field type translates to a textarea
                 nga.field('body', 'wysiwyg'), // overriding the type allows rich text editing for the body
-                nga.field('published_at', 'date') // Date field type translates to a datepicker
+                nga.field('published_at', 'date'), // Date field type translates to a datepicker
+                nga.field('tags', 'reference_many') // ReferenceMany translates to a select multiple
+                    .targetEntity(tag)
+                    .targetField(nga.field('name'))
+                    .attributes({ placeholder: 'Select some tags...' })
+                    .remoteComplete(true, {
+                        refreshDelay: 300,
+                        searchQuery: function(search) { return { q: search }; }
+                    })
+                    .singleApiCall(ids => { return {'id': ids }})
+                    .cssClasses('col-sm-4'), // customize look and feel through CSS classes
             ]);
 
         post.editionView()
@@ -138,15 +148,6 @@
                             return c.category === entry.values.category;
                         });
                     }),
-                nga.field('tags', 'reference_many') // ReferenceMany translates to a select multiple
-                    .targetEntity(tag)
-                    .targetField(nga.field('name'))
-                    .attributes({ placeholder: 'Select some tags...' })
-                    .remoteComplete(true, {
-                        refreshDelay: 300 ,
-                        searchQuery: function(search) { return { q: search }; }
-                    })
-                    .cssClasses('col-sm-4'), // customize look and feel through CSS classes
                 nga.field('pictures', 'json'),
                 nga.field('views', 'number')
                     .cssClasses('col-sm-4'),

--- a/src/javascripts/ng-admin/Crud/field/maReferenceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maReferenceField.js
@@ -20,10 +20,12 @@ function maReferenceField(ReferenceRefresher) {
             }
 
             if (field.remoteComplete()) {
-                ReferenceRefresher.getInitialChoices(field, [scope.value])
-                    .then(options => {
-                        scope.$broadcast('choices:update', { choices: options });
-                    });
+                if (scope.value) {
+                    ReferenceRefresher.getInitialChoices(field, [scope.value])
+                        .then(options => {
+                            scope.$broadcast('choices:update', { choices: options });
+                        });
+                }
 
                 scope.refresh = refresh;
             } else {
@@ -42,4 +44,3 @@ function maReferenceField(ReferenceRefresher) {
 maReferenceField.$inject = ['ReferenceRefresher'];
 
 module.exports = maReferenceField;
-

--- a/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
@@ -1,12 +1,11 @@
 /* globals _ */
 
-var ListLayoutController = function ($scope, $stateParams, $state, $location, $timeout, view, dataStore) {
+var ListLayoutController = function ($scope, $stateParams, $state, $location, $timeout, view) {
     this.$scope = $scope;
     this.$state = $state;
     this.$stateParams = $stateParams;
     this.$timeout = $timeout;
     this.view = view;
-    this.dataStore = dataStore;
     this.entity = view.getEntity();
     this.actions = view.actions();
     this.batchActions = view.batchActions();
@@ -113,9 +112,8 @@ ListLayoutController.prototype.destroy = function () {
     this.$state = undefined;
     this.$stateParams = undefined;
     this.$timeout = undefined;
-    this.dataStore = undefined;
 };
 
-ListLayoutController.$inject = ['$scope', '$stateParams', '$state', '$location', '$timeout', 'view', 'dataStore'];
+ListLayoutController.$inject = ['$scope', '$stateParams', '$state', '$location', '$timeout', 'view'];
 
 module.exports = ListLayoutController;

--- a/src/javascripts/ng-admin/Crud/repository/ReferenceRefresher.js
+++ b/src/javascripts/ng-admin/Crud/repository/ReferenceRefresher.js
@@ -21,7 +21,13 @@ class ReferenceRefresher {
     }
 
     getInitialChoices(field, values) {
-        return this.ReadQueries.getRecordsByIds(field.targetEntity(), values)
+        let call;
+        if (field.hasSingleApiCall()) {
+            call = this.ReadQueries.getOptimizedRecordsByIds(field.targetEntity(), field.getSingleApiCall(values))
+        } else {
+            call = this.ReadQueries.getRecordsByIds(field.targetEntity(), values)
+        }
+        return call
             .then(results => this._removeDuplicates(results, values))
             .then(records => this._transformRecords(field, records));
     }

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -51,22 +51,7 @@ function routing($stateProvider) {
             controllerAs: 'llCtrl',
             templateProvider: templateProvider('ListView', listLayoutTemplate),
             resolve: {
-                dataStore: () => new DataStore(),
                 view: viewProvider('ListView'),
-                filterData: ['ReadQueries', 'view', function (ReadQueries, view) {
-                    return ReadQueries.getAllReferencedData(view.getFilterReferences(false));
-                }],
-                filterEntries: ['dataStore', 'view', 'filterData', function (dataStore, view, filterData) {
-                    const filters = view.getFilterReferences(false);
-                    for (var name in filterData) {
-                        Entry.createArrayFromRest(
-                            filterData[name],
-                            [filters[name].targetField()],
-                            filters[name].targetEntity().name(),
-                            filters[name].targetEntity().identifier().name()
-                        ).map(entry => dataStore.addEntry(filters[name].targetEntity().uniqueId + '_choices', entry));
-                    }
-                }]
             }
         })
         .state('list', {
@@ -237,20 +222,6 @@ function routing($stateProvider) {
 
                     return entry;
                 }],
-                choiceData: ['ReadQueries', 'view', function (ReadQueries, view) {
-                    return ReadQueries.getAllReferencedData(view.getReferences(false));
-                }],
-                choiceEntries: ['dataStore', 'view', 'choiceData', function (dataStore, view, filterData) {
-                    const choices = view.getReferences(false);
-                    for (var name in filterData) {
-                        Entry.createArrayFromRest(
-                            filterData[name],
-                            [choices[name].targetField()],
-                            choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier().name()
-                        ).map(entry => dataStore.addEntry(choices[name].targetEntity().uniqueId + '_choices', entry));
-                    }
-                }]
             }
         });
 
@@ -278,20 +249,6 @@ function routing($stateProvider) {
                 entry: ['view', 'rawEntry', function(view, rawEntry) {
                     return view.mapEntry(rawEntry);
                 }],
-                referenceData: ['ReadQueries', 'view', 'entry', function (ReadQueries, view, entry) {
-                    return ReadQueries.getReferenceData(view.fields(), [entry.values]);
-                }],
-                referenceEntries: ['dataStore', 'view', 'referenceData', function (dataStore, view, referenceData) {
-                    const references = view.getReferences();
-                    for (var name in referenceData) {
-                        Entry.createArrayFromRest(
-                            referenceData[name],
-                            [references[name].targetField()],
-                            references[name].targetEntity().name(),
-                            references[name].targetEntity().identifier().name()
-                        ).map(entry => dataStore.addEntry(references[name].targetEntity().uniqueId + '_values', entry))
-                    }
-                }],
                 referencedListData: ['$stateParams', 'ReadQueries', 'view', 'entry', function ($stateParams, ReadQueries, view, entry) {
                     return ReadQueries.getReferencedListData(view.getReferencedLists(), $stateParams.sortField, $stateParams.sortDir, entry.identifierValue);
                 }],
@@ -306,23 +263,8 @@ function routing($stateProvider) {
                         ).map(entry => dataStore.addEntry(referencedLists[name].targetEntity().uniqueId + '_list', entry))
                     }
                 }],
-                entryWithReferences: ['dataStore', 'view', 'entry', 'referenceEntries', function(dataStore, view, entry, referenceEntries) {
-                    dataStore.fillReferencesValuesFromEntry(entry, view.getReferences(), true);
+                addEntryToDataStore: ['dataStore', 'view', 'entry', function(dataStore, view, entry) {
                     dataStore.addEntry(view.getEntity().uniqueId, entry);
-                }],
-                choiceData: ['ReadQueries', 'view', function (ReadQueries, view) {
-                    return ReadQueries.getAllReferencedData(view.getReferences(false));
-                }],
-                choiceEntries: ['dataStore', 'view', 'choiceData', function (dataStore, view, filterData) {
-                    const choices = view.getReferences(false);
-                    for (var name in filterData) {
-                        Entry.createArrayFromRest(
-                            filterData[name],
-                            [choices[name].targetField()],
-                            choices[name].targetEntity().name(),
-                            choices[name].targetEntity().identifier().name()
-                        ).map(entry => dataStore.addEntry(choices[name].targetEntity().uniqueId + '_choices', entry));
-                    }
                 }],
                 referenceDataForReferencedLists: ['$q', 'ReadQueries', 'view', 'referencedListData', function ($q,ReadQueries, view, referencedListData) {
                     const referencedLists = view.getReferencedLists();

--- a/src/javascripts/test/unit/Crud/repository/ReferenceRefresherSpec.js
+++ b/src/javascripts/test/unit/Crud/repository/ReferenceRefresherSpec.js
@@ -26,7 +26,8 @@ describe('ReferenceRefresher', function() {
                     getMappedValue: v => v
                 }
             },
-            type: () => 'reference'
+            type: () => 'reference',
+            hasSingleApiCall: () => false,
         };
     });
 
@@ -122,7 +123,8 @@ describe('ReferenceRefresher', function() {
                         getMappedValue: (v, e) => `${e.title} (#${e.id})`
                     }
                 },
-                type: () => 'reference'
+                type: () => 'reference',
+                hasSingleApiCall: () => false,
             };
 
             var refresher = new ReferenceRefresher(readQueries);
@@ -171,7 +173,8 @@ describe('ReferenceRefresher', function() {
                         getMappedValue: (v, e) => `${e.title} (#${e.id})`
                     }
                 },
-                type: () => 'reference'
+                type: () => 'reference',
+                hasSingleApiCall: () => false,
             };
             refresher.getInitialChoices(fakeField, [1, 2]).then(function(results) {
                 expect(results).toEqual([


### PR DESCRIPTION
* [x] Fix duplicate calls to API using `reference` and `reference_many fields` (fix #712)
* [x] Fix `reference` field was doing an API call without limit when field has no value
* [x] Fix doc configuration reference code block indentation

Need https://github.com/marmelab/admin-config/pull/45.