### PR TITLE
[WIP][BC BREAKS] Exclude angular from ng-admin-only package + introduce ng-admin-vendors-js and ng-admin-vendors-css packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist
 .sass-cache
 src/javascripts/bower_components
 src/javascripts/config.js
-src/javascripts/test/fixtures/examples/blog
 src/styles/*.css
 src/css
 examples/blog/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
   - gem update --system
   - gem install compass
-before_script:
-  - "./node_modules/protractor/bin/webdriver-manager update"
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 
 run: examples/blog/build
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
+	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
 	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
 	@./node_modules/webpack-dev-server/bin/webpack-dev-server.js --colors --devtool cheap-module-inline-source-map --content-base examples/blog --port 8000
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run: examples/blog/build
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
 	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
 	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
-	@./node_modules/webpack-dev-server/bin/webpack-dev-server.js --minimize --colors --devtool cheap-module-inline-source-map --content-base examples/blog --port 8000
+	@./node_modules/.bin/webpack-dev-server --minimize --colors --devtool cheap-module-inline-source-map --hot --inline --content-base examples/blog --host=0.0.0.0 --port 8000
 
 examples/blog/build:
 	@mkdir examples/blog/build
@@ -30,4 +30,4 @@ prepare-test-e2e:
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
 	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
 	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
-	@NODE_ENV=test ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe
+	@./node_modules/.bin/webpack -p --optimize-minimize --optimize-occurence-order --optimize-dedupe

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,7 @@ test-e2e: prepare-test-e2e
 
 prepare-test-e2e:
 	@echo "Preparing files for e2e tests"
+	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
+	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
+	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
 	@NODE_ENV=test ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 install:
 	npm install
-	./node_modules/protractor/bin/webdriver-manager update
 
 run: examples/blog/build
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ run: examples/blog/build
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
 	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
 	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
-	@./node_modules/webpack-dev-server/bin/webpack-dev-server.js --colors --devtool cheap-module-inline-source-map --content-base examples/blog --port 8000
+	@./node_modules/webpack-dev-server/bin/webpack-dev-server.js --minimize --colors --devtool cheap-module-inline-source-map --content-base examples/blog --port 8000
 
 examples/blog/build:
 	@mkdir examples/blog/build
@@ -29,8 +29,3 @@ test-e2e: prepare-test-e2e
 prepare-test-e2e:
 	@echo "Preparing files for e2e tests"
 	@NODE_ENV=test ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe
-	@cp examples/blog/*.js src/javascripts/test/fixtures/examples/blog
-	@cp examples/blog/*.html src/javascripts/test/fixtures/examples/blog
-	@sed -i.bak 's|http://localhost:8000/|/|g' src/javascripts/test/fixtures/examples/blog/index.html
-	@cp node_modules/fakerest/dist/FakeRest.min.js src/javascripts/test/fixtures/examples/blog/build/fakerest.js
-	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js src/javascripts/test/fixtures/examples/blog/build/sinon-server.js

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-e2e: prepare-test-e2e
 
 prepare-test-e2e:
 	@echo "Preparing files for e2e tests"
+	@NODE_ENV=test ./node_modules/.bin/webpack -p --optimize-minimize --optimize-occurence-order --optimize-dedupe
 	@cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js
 	@cp node_modules/angular/angular.min.js examples/blog/build/angular.min.js
 	@cp node_modules/sinon/pkg/sinon-server-1.14.1.js examples/blog/build/sinon-server.js
-	@./node_modules/.bin/webpack -p --optimize-minimize --optimize-occurence-order --optimize-dedupe

--- a/examples/blog/index.html
+++ b/examples/blog/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <title>Angular admin</title>
         <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" href="http://localhost:8000/build/ng-admin.min.css">
+        <link rel="stylesheet" href="build/ng-admin.min.css">
         <style type="text/css">
             .ng-admin-entity-posts .ng-admin-column-title {
                 max-width: 250px;
@@ -13,14 +13,14 @@
     </head>
     <body ng-app="myApp" ng-strict-di>
         <div ui-view></div>
-        <script src="http://localhost:8000/build/angular.min.js" type="text/javascript"></script>
-        <script src="http://localhost:8000/build/ng-admin-vendors-js.min.js" type="text/javascript"></script>
+        <script src="build/angular.min.js" type="text/javascript"></script>
+        <script src="build/ng-admin-vendors-js.min.js" type="text/javascript"></script>
         <script src="build/fakerest.js" type="text/javascript"></script>
         <script src="build/sinon-server.js" type="text/javascript"></script>
         <script src="data.js" type="text/javascript"></script>
         <script src="fakerest-init.js" type="text/javascript"></script>
-        <script src="http://localhost:8000/build/ng-admin-only.min.js" type="text/javascript"></script>
-        <script src="http://localhost:8000/build/ng-admin-vendors-css.min.js" type="text/javascript"></script>
+        <script src="build/ng-admin-only.min.js" type="text/javascript"></script>
+        <script src="build/ng-admin-vendors-css.min.js" type="text/javascript"></script>
         <script src="config.js" type="text/javascript"></script>
     </body>
 </html>

--- a/examples/blog/index.html
+++ b/examples/blog/index.html
@@ -13,11 +13,14 @@
     </head>
     <body ng-app="myApp" ng-strict-di>
         <div ui-view></div>
+        <script src="http://localhost:8000/build/angular.min.js" type="text/javascript"></script>
+        <script src="http://localhost:8000/build/ng-admin-vendors-js.min.js" type="text/javascript"></script>
         <script src="build/fakerest.js" type="text/javascript"></script>
         <script src="build/sinon-server.js" type="text/javascript"></script>
         <script src="data.js" type="text/javascript"></script>
         <script src="fakerest-init.js" type="text/javascript"></script>
-        <script src="http://localhost:8000/build/ng-admin.min.js" type="text/javascript"></script>
+        <script src="http://localhost:8000/build/ng-admin-only.min.js" type="text/javascript"></script>
+        <script src="http://localhost:8000/build/ng-admin-vendors-css.min.js" type="text/javascript"></script>
         <script src="config.js" type="text/javascript"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node": ">=4.2.0"
   },
   "scripts": {
+    "postinstall": "webdriver-manager update",
     "test": "make test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "angular-ui-bootstrap": "~1.2.1",
     "angular-ui-codemirror": "^0.3.0",
     "angular-ui-router": "^0.2.14",
-    "angularjs": "0.0.1",
     "babel": "^4.6.0",
     "babel-core": "^5.2.17",
     "babel-loader": "^5.0.0",
@@ -76,7 +75,7 @@
     "node": ">=4.2.0"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update",
+    "postinstall": "if [ -z \"$npm_config_production\" ]; then webdriver-manager update; fi",
     "test": "make test"
   }
 }

--- a/src/javascripts/ng-admin.js
+++ b/src/javascripts/ng-admin.js
@@ -1,5 +1,3 @@
-require('es6-promise').polyfill(); // for IE
-
 require('./ng-admin/Main/MainModule');
 require('./ng-admin/Crud/CrudModule');
 

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 var CrudModule = angular.module('crud', [
     'ui.router', 'ui.bootstrap', 'ngSanitize', 'textAngular', 'ngInflection', 'ui.codemirror', 'ngFileUpload', 'ngNumeraljs'
 ]);
@@ -86,18 +84,17 @@ CrudModule.config(require('./routing'));
 CrudModule.config(require('./config/factories'));
 
 CrudModule.factory('Papa', function () {
-    return require('papaparse');
+    return global.Papa;
 });
 
 CrudModule.factory('notification', function () {
-    var humane = require('humane-js');
-    humane.timeout = 5000;
-    humane.clickToClose = true;
+    global.humane.timeout = 5000;
+    global.humane.clickToClose = true;
     return humane;
 });
 
 CrudModule.factory('progression', function () {
-    return require('nprogress');
+    return global.NProgress;
 });
 
 CrudModule.run(['Restangular', 'NgAdminConfiguration', function(Restangular, NgAdminConfiguration) {

--- a/src/javascripts/ng-admin/Crud/field/maJsonField.js
+++ b/src/javascripts/ng-admin/Crud/field/maJsonField.js
@@ -1,25 +1,3 @@
-var codemirror = require('codemirror');
-
-global.jsonlint = require('jsonlint/web/jsonlint.js');
-
-require('codemirror/addon/edit/closebrackets');
-require('codemirror/addon/edit/matchbrackets');
-require('codemirror/addon/lint/lint');
-require('codemirror/addon/lint/json-lint');
-require('codemirror/addon/selection/active-line');
-require('codemirror/mode/javascript/javascript');
-
-codemirror.defineOption("matchBrackets", true);
-codemirror.defineOption("autoCloseBrackets", true);
-codemirror.defineOption("lineWrapping", true);
-codemirror.defineOption("tabSize", 2);
-codemirror.defineOption("mode", "application/json");
-codemirror.defineOption("gutters", ["CodeMirror-lint-markers"]);
-codemirror.defineOption("lint", true);
-codemirror.defineOption("styleActiveLine", true);
-
-global.CodeMirror = codemirror;
-
 /**
  * Edition field for a JSON string in a textarea.
  *

--- a/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 export default function maDatagridInfinitePagination($window, $document) {
 
     var windowElement = angular.element($window);

--- a/src/javascripts/ng-admin/Crud/list/maDatagridPaginationController.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridPaginationController.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 export default class DatagridPaginationController {
     constructor($scope) {
         this.$scope = $scope;

--- a/src/javascripts/ng-admin/Main/MainModule.js
+++ b/src/javascripts/ng-admin/Main/MainModule.js
@@ -1,8 +1,3 @@
-import angular from 'angular';
-
-require('angular-ui-router');
-require('restangular');
-
 var MainModule = angular.module('main', ['ui.router', 'restangular']);
 
 MainModule.controller('AppController', require('./component/controller/AppController'));

--- a/src/javascripts/ng-admin/Main/component/directive/maMenuBar.js
+++ b/src/javascripts/ng-admin/Main/component/directive/maMenuBar.js
@@ -1,5 +1,4 @@
 import menuBarView from '../../view/menuBar.html';
-import angular from 'angular';
 
 export default function maMenuBar($location, $rootScope, $compile) {
     return {

--- a/src/javascripts/test/protractor.conf.js
+++ b/src/javascripts/test/protractor.conf.js
@@ -6,7 +6,7 @@ var server = function() {
     const server = jsonServer.create();
 
     server.use(jsonServer.defaults({
-        static: path.join(__dirname, '/fixtures/examples/blog'),
+        static: path.join(__dirname, '/../../../examples/blog'),
         logger: false
     }));
 
@@ -21,6 +21,16 @@ var beforeLaunch = function () {
 
 var onPrepare = function () {
     browser.executeScript('window.name = "NG_ENABLE_DEBUG_INFO"');
+
+    // Disable animations so e2e tests run more quickly
+    const disableNgAnimate = () => {
+        angular.module('disableNgAnimate', []).run([
+            '$animate', function ($animate) {
+                $animate.enabled(false);
+            }
+        ]);
+    };
+    browser.addMockModule('disableNgAnimate', disableNgAnimate);
 }
 
 var afterLaunch = function () {

--- a/src/javascripts/vendors.js
+++ b/src/javascripts/vendors.js
@@ -1,3 +1,33 @@
+require('es6-promise').polyfill(); // for IE
+
+require('../../node_modules/restangular/dist/restangular.js');
+window.NProgress = require('../../node_modules/nprogress/nprogress.js');
+window.Papa = require('../../node_modules/papaparse/papaparse.js');
+window.humane = require('../../node_modules/humane-js/humane.js');
+window.jsonlint = require('../../node_modules/jsonlint/web/jsonlint.js');
+
+var codemirror = require('codemirror');
+
+global.jsonlint = require('jsonlint/web/jsonlint.js');
+
+require('codemirror/addon/edit/closebrackets');
+require('codemirror/addon/edit/matchbrackets');
+require('codemirror/addon/lint/lint');
+require('codemirror/addon/lint/json-lint');
+require('codemirror/addon/selection/active-line');
+require('codemirror/mode/javascript/javascript');
+
+codemirror.defineOption("matchBrackets", true);
+codemirror.defineOption("autoCloseBrackets", true);
+codemirror.defineOption("lineWrapping", true);
+codemirror.defineOption("tabSize", 2);
+codemirror.defineOption("mode", "application/json");
+codemirror.defineOption("gutters", ["CodeMirror-lint-markers"]);
+codemirror.defineOption("lint", true);
+codemirror.defineOption("styleActiveLine", true);
+
+global.CodeMirror = codemirror;
+
 global.rangy = require('../../node_modules/rangy/lib/rangy-core');
 global.rangy = require('../../node_modules/rangy/lib/rangy-selectionsaverestore');
 global.numeral = require('numeral');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 function getEntrySources(sources) {
@@ -8,23 +9,11 @@ function getEntrySources(sources) {
     return sources;
 }
 
-var ngAdminSources = [
-    './src/javascripts/ng-admin.js',
-    './src/sass/ng-admin.scss'
+var ngAdminJsSources = [
+    './src/javascripts/ng-admin.js'
 ];
 
-var ngAdminAndVendorSources = [
-    'angular/angular.js',
-    './src/javascripts/ng-admin.js',
-    './src/javascripts/vendors.js',
-    'font-awesome/scss/font-awesome.scss',
-    'bootstrap-sass/assets/stylesheets/_bootstrap.scss',
-    'nprogress/nprogress.css',
-    'humane-js/themes/flatty.css',
-    'textangular/src/textAngular.css',
-    'codemirror/lib/codemirror.css',
-    'codemirror/addon/lint/lint.css',
-    'ui-select/dist/select.css',
+var ngAdminCssSources = [
     './src/sass/ng-admin.scss'
 ];
 
@@ -40,14 +29,13 @@ var vendorsCssSources = [
     'textangular/src/textAngular.css',
     'codemirror/lib/codemirror.css',
     'codemirror/addon/lint/lint.css',
-    'ui-select/dist/select.css',
-    './src/sass/ng-admin.scss'
+    'ui-select/dist/select.css'
  ];
 
 module.exports = {
     entry: {
-        'ng-admin': getEntrySources(ngAdminAndVendorSources),
-        'ng-admin-only': getEntrySources(ngAdminSources),
+        'ng-admin': getEntrySources(['angular'].concat(vendorsJsSources.concat(ngAdminJsSources).concat(vendorsCssSources).concat(ngAdminCssSources))),
+        'ng-admin-only': getEntrySources(ngAdminJsSources.concat(ngAdminCssSources)),
         'ng-admin-vendors-js': getEntrySources(vendorsJsSources),
         'ng-admin-vendors-css': getEntrySources(vendorsCssSources)
     },
@@ -57,9 +45,6 @@ module.exports = {
     } : {
         publicPath: "http://localhost:8000/",
         filename: "build/[name].min.js"
-    },
-    externals: {
-        'angular': 'angular'
     },
     module: {
         loaders: [
@@ -75,5 +60,5 @@ module.exports = {
         new ExtractTextPlugin('build/[name].min.css', {
             allChunks: true
         })
-    ]
+    ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,6 @@
 var path = require('path');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-function getEntrySources(sources) {
-    if (process.env.NODE_ENV !== 'production') { // for live reload
-        sources.push('webpack-dev-server/client?http://0.0.0.0:8000');
-    }
-
-    return sources;
-}
-
 var ngAdminJsSources = [
     './src/javascripts/ng-admin.js'
 ];
@@ -34,16 +26,13 @@ var vendorsCssSources = [
 
 module.exports = {
     entry: {
-        'ng-admin': getEntrySources(['angular'].concat(vendorsJsSources.concat(ngAdminJsSources).concat(vendorsCssSources).concat(ngAdminCssSources))),
-        'ng-admin-only': getEntrySources(ngAdminJsSources.concat(ngAdminCssSources)),
-        'ng-admin-vendors-js': getEntrySources(vendorsJsSources),
-        'ng-admin-vendors-css': getEntrySources(vendorsCssSources)
+        'ng-admin': ['angular'].concat(vendorsJsSources.concat(ngAdminJsSources).concat(vendorsCssSources).concat(ngAdminCssSources)),
+        'ng-admin-only': ngAdminJsSources.concat(ngAdminCssSources),
+        'ng-admin-vendors-js': vendorsJsSources,
+        'ng-admin-vendors-css': vendorsCssSources
     },
-    output: process.env.NODE_ENV === 'test' ? {
-        path: './src/javascripts/test/fixtures/examples/blog/',
-        filename: "build/[name].min.js"
-    } : {
-        publicPath: "http://localhost:8000/",
+    output: {
+        publicPath: "/",
         filename: "build/[name].min.js"
     },
     module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ var ngAdminSources = [
 ];
 
 var ngAdminAndVendorSources = [
+    'angular/angular.js',
     './src/javascripts/ng-admin.js',
     './src/javascripts/vendors.js',
     'font-awesome/scss/font-awesome.scss',
@@ -27,10 +28,28 @@ var ngAdminAndVendorSources = [
     './src/sass/ng-admin.scss'
 ];
 
+var vendorsJsSources = [
+    './src/javascripts/vendors.js'
+];
+
+var vendorsCssSources = [
+    'font-awesome/scss/font-awesome.scss',
+    'bootstrap-sass/assets/stylesheets/_bootstrap.scss',
+    'nprogress/nprogress.css',
+    'humane-js/themes/flatty.css',
+    'textangular/src/textAngular.css',
+    'codemirror/lib/codemirror.css',
+    'codemirror/addon/lint/lint.css',
+    'ui-select/dist/select.css',
+    './src/sass/ng-admin.scss'
+ ];
+
 module.exports = {
     entry: {
         'ng-admin': getEntrySources(ngAdminAndVendorSources),
-        'ng-admin-only': getEntrySources(ngAdminSources)
+        'ng-admin-only': getEntrySources(ngAdminSources),
+        'ng-admin-vendors-js': getEntrySources(vendorsJsSources),
+        'ng-admin-vendors-css': getEntrySources(vendorsCssSources)
     },
     output: process.env.NODE_ENV === 'test' ? {
         path: './src/javascripts/test/fixtures/examples/blog/',
@@ -38,6 +57,9 @@ module.exports = {
     } : {
         publicPath: "http://localhost:8000/",
         filename: "build/[name].min.js"
+    },
+    externals: {
+        'angular': 'angular'
     },
     module: {
         loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,10 @@ module.exports = {
         'ng-admin-vendors-js': vendorsJsSources,
         'ng-admin-vendors-css': vendorsCssSources
     },
-    output: {
+    output: process.env.NODE_ENV === 'test' ? {
+        path: './examples/blog/',
+        filename: "build/[name].min.js"
+    } : {
         publicPath: "/",
         filename: "build/[name].min.js"
     },


### PR DESCRIPTION
* [x] BC Break: `ng-admin-only.js` does not include any vendors anymore (`ng-admin.js` always includes vendors, no change here)
* [x] Move `webdriver-manager update` command to npm postinstall
* [x] Builded files for tests are now identically to committed build files.
* [x] Diable ng-animate in e2e tests to speed up them
* [x] Use `--hot` and `--inline` flags for `webpack-dev-server`
* [ ] Update README, UPGRADE and documentation

Here is the result:
![image](https://cloud.githubusercontent.com/assets/582446/13817835/fc28004c-eb93-11e5-82b8-470624158431.png)

Sinon server (used by fakerest) will now make a better job in demo as it is initialized before including vendors, ng-admin and restangular initialisation (for example, we will be able to fake an upload).