### PR TITLE
[RFR] Add support for the `View.prepare()` logic

### DIFF
--- a/doc/Custom-types.md
+++ b/doc/Custom-types.md
@@ -240,19 +240,19 @@ Fetching data from the `link()` function of a directive has drawbacks:
 
 The alternative is to prepare the data before the page starts rendering, to store it in the `datastore`, and to pass the `datastore` to the custom directive.
 
-Fortunately, every view has a `prepare()` method, which expects a function as parameter. This function is executed before the view is rendered. It receives the current DataStore instance (already filled with all the entries required by the view). It's the ideal place to group fetches to a remote API, and store the results in the `datastore`:
+Fortunately, every view has a `prepare()` method, which expects a function as parameter. This function is executed before the view is rendered. It's the ideal place to group fetches to a remote API, and store the results in the `datastore`. The `prepare()` function uses the Angular Dependency Injection system, so you can require any service defined previously in the controller logic - like the current DataStore instance (already filled with all the entries required by the view).
 
 ```js
-product.listView().prepare({ datastore, view }) => {
+product.listView().prepare(['$http', 'datastore', 'view', function($http, datastore, view) {
     const fromCurrency = view.getField('price').currency();
     return $http.get(`http://myconverter.example.com?fromCurrency=${fromCurrency}&toCurrency=USD`)
         .then(response => {
             datastore.addEntry('conversionRate', response.value)
         });
-})
+}])
 ```
 
-The directives doesn't need `$http` anymore, but can use the `dataStore` instead:
+The directives doesn't need `$http` anymore, but can use the `datastore` instead:
 
 ```js
 function amountStringDirective($http) {

--- a/doc/Custom-types.md
+++ b/doc/Custom-types.md
@@ -9,7 +9,7 @@ A ng-admin *type* has two components:
 - a Field class, used to configure the field
 - a FieldView class, used for rendering
 
-Let's see that through an example: the `number` type. 
+Let's see that through an example: the `number` type.
 
 When you define a field with `nga.field()`, the second argument is the field type ('string' by default). `nga.field()` is a factory method returning an specialized instance of [the `Field` class](https://github.com/marmelab/admin-config/blob/master/lib/Field/Field.js). For instance:
 
@@ -32,7 +32,7 @@ class NumberField extends Field {
     }
 
     /**
-     * Specify format pattern for number to string conversion. 
+     * Specify format pattern for number to string conversion.
      */
     format(value) {
         if (!arguments.length) return this._format;
@@ -197,6 +197,92 @@ myApp.directive('amountString', require('path/to/amountStringDirective.js'));
 // in AmountFieldView.js
 export default {
     getReadWidget:   () => '<amount-string field="::field" value="::entry.values[field.name()]"></amount-string>',
+    // ...
+};
+```
+
+## Fetching data
+
+Custom directives can fetch data, too. For instance, the `<amount-string>` directive can fetch the conversion rate to another currency, and display the amount in more than one currency. To fetch a remote API, use either the `Restangular` service, or `$http` if you prefer.
+
+```js
+function amountStringDirective($http) {
+    return {
+        restrict: 'E',
+        scope: {
+            value: '&',
+            field: '&'
+        },
+        link: function(scope) {
+            scope.fromCurrency = field().currency();
+            scope.conversionRate = 1;
+            scope.format = field().format();
+            $http.get(`http://myconverter.example.com?fromCurrency=${scope.fromCurrency}&toCurrency=USD`)
+                .then(response => {
+                    scope.conversionRate = response.value;
+                });
+        },
+        template: `<span>{{ fromCurrency }} {{ value() | numeraljs:format }}</span>
+                   (<span> USD {{ value() * conversionRate | numeraljs:format }}</span>)`
+    };
+}
+amountStringDirective.$inject = ['$http'];
+
+export default amountStringDirective;
+```
+
+## Fetching Data Before Rendering
+
+Fetching data from the `link()` function of a directive has drawbacks:
+
+- it triggers redraws of the page when the remote response arrives
+- in a `listView`, a custom directive will make a lot of queries (one per entry)
+
+The alternative is to prepare the data before the page starts rendering, to store it in the `datastore`, and to pass the `datastore` to the custom directive.
+
+Fortunately, every view has a `prepare()` method, which expects a function as parameter. This function is executed before the view is rendered. It receives the current DataStore instance (already filled with all the entries required by the view). It's the ideal place to group fetches to a remote API, and store the results in the `datastore`:
+
+```js
+product.listView().prepare({ datastore, view }) => {
+    const fromCurrency = view.getField('price').currency();
+    return $http.get(`http://myconverter.example.com?fromCurrency=${fromCurrency}&toCurrency=USD`)
+        .then(response => {
+            datastore.addEntry('conversionRate', response.value)
+        });
+})
+```
+
+The directives doesn't need `$http` anymore, but can use the `dataStore` instead:
+
+```js
+function amountStringDirective($http) {
+    return {
+        restrict: 'E',
+        scope: {
+            value: '&',
+            field: '&',
+            datastore: '&'
+        },
+        link: function(scope) {
+            scope.fromCurrency = field().currency();
+            scope.conversionRate = 1;
+            scope.format = field().format();
+            scope.convertedValue = datastore.getFirstEntry('conversionRate') * scope.value();
+        },
+        template: `<span>{{ fromCurrency }} {{ value() | numeraljs:format }}</span>
+                   (<span> USD {{ convertedValue | numeraljs:format }}</span>)`
+    };
+}
+
+export default amountStringDirective;
+```
+
+The `datastore` just needs to be declared in the `fieldView`:
+
+```js
+// in AmountFieldView.js
+export default {
+    getReadWidget:   () => '<amount-string field="::field" datastore="::datastore" value="::entry.values[field.name()]"></amount-string>',
     // ...
 };
 ```

--- a/doc/reference/View.md
+++ b/doc/reference/View.md
@@ -182,7 +182,7 @@ Add a function to be executed before the view renders.
      - `Entry`: the Entry constructor (required to transform an object from the REST response to an Entry)
      - `window`: the window object. If you need to fetch anything other than an entry and pass it to the view layer, it's the only way.
 
-        post.listView().prepare({ dataStore, view, Entry }) => {
+        post.listView().prepare({ datastore, view, Entry }) => {
           const posts = datastore.getEntries(view.getEntity().uniqueId);
           const authorIds = posts.map(post => post.values.authorId).join(',');
           return fetch('http://myapi.com/authors?id[]=' + authorIds)

--- a/doc/reference/View.md
+++ b/doc/reference/View.md
@@ -167,3 +167,30 @@ Set the fields for the CSV export function. By default, ng-admin uses the fields
             nga.field('body', 'wysiwyg')
                 .stripTags(true)
         ]);
+
+* `prepare(Function)`
+Add a function to be executed before the view renders.
+
+    This is the ideal place to prefetch related entities and manipulate the dataStore. The function can be asynchronous, in which case it should return a Promise.
+
+    The prepare function receives a context argument with the following properties:
+
+     - `query`: the query object (an object representation of the main request query string)
+     - `datastore`: where the Entries are stored. The dataStore is accessible during rendering
+     - `view`: the current View object
+     - `entry`: the current Entry instance (except in listView)
+     - `Entry`: the Entry constructor (required to transform an object from the REST response to an Entry)
+     - `window`: the window object. If you need to fetch anything other than an entry and pass it to the view layer, it's the only way.
+
+        post.listView().prepare({ dataStore, view, Entry }) => {
+          const posts = datastore.getEntries(view.getEntity().uniqueId);
+          const authorIds = posts.map(post => post.values.authorId).join(',');
+          return fetch('http://myapi.com/authors?id[]=' + authorIds)
+             .then(response => response.json())
+             .then(authors => Entry.createArrayFromRest(
+                 authors,
+                 [new Field('first_name'), new Field('last_name')],
+                 'author'
+             ))
+             .then(authorEntries => datastore.setEntries('authors', authorEntries));
+        })

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -324,7 +324,7 @@
                 nga.field('id').label('ID'),
                 nga.field('name'),
                 nga.field('published', 'boolean').cssClasses(function(entry) { // add custom CSS classes to inputs and columns
-                    if(entry && entry.values){
+                    if (entry && entry.values){
                         if (entry.values.published) {
                             return 'bg-success text-center';
                         }
@@ -334,7 +334,8 @@
                 nga.field('custom')
                     .label('Upper name')
                     .template('{{ entry.values.name.toUpperCase() }}')
-                    .cssClasses('hidden-xs')
+                    .cssClasses('hidden-xs'),
+                nga.field('nb_posts')
             ])
             .filters([
                 nga.field('published')
@@ -344,6 +345,26 @@
             ])
             .batchActions([]) // disable checkbox column and batch delete
             .listActions(['show', 'edit']);
+
+        // define custom controller logic for the tag listView
+        tag.listView().prepare(['Restangular', 'entries', function(Restangular, entries) {
+            // fetch the number of posts for each tag
+            return Restangular.allUrl('posts').getList()
+                .then(function(response) {
+                    const nbPostsByTag = {};
+                    response.data.forEach(function(post) {
+                        post.tags.forEach(function(tagId) {
+                            if (!nbPostsByTag[tagId]) {
+                                nbPostsByTag[tagId] = 0;
+                            }
+                            nbPostsByTag[tagId]++;
+                        });
+                    });
+                    entries.map(function(tag) {
+                        tag.values.nb_posts = nbPostsByTag[tag.identifierValue];
+                    });
+                });
+        }]);
 
         tag.editionView()
             .fields([

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.5.1",
+    "admin-config": "^0.6.0",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.6.0",
+    "admin-config": "^0.6.1",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -98,4 +98,8 @@ CrudModule.factory('progression', function () {
     return require('nprogress');
 });
 
+CrudModule.run(['Restangular', 'NgAdminConfiguration', function(Restangular, NgAdminConfiguration) {
+    Restangular.setBaseUrl(NgAdminConfiguration().baseApiUrl());
+}]);
+
 module.exports = CrudModule;

--- a/src/javascripts/ng-admin/Crud/column/maReferenceColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maReferenceColumn.js
@@ -14,9 +14,7 @@ function maReferenceColumn() {
                 scope.targetField = scope.field.targetField();
                 const identifierName = scope.targetEntity.identifier().name()
                 scope.referencedEntry = scope.datastore()
-                    .getEntries(scope.targetEntity.uniqueId + '_values')
-                    .filter(entry => entry.values[identifierName] == value)
-                    .pop();
+                    .getFirstEntry(scope.targetEntity.uniqueId + '_values', entry => entry.values[identifierName] == value);
             }
         },
         template: '<ma-column field="::targetField" entry="::referencedEntry" entity="::targetEntity" datastore="::datastore()"></ma-column>'

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -123,14 +123,15 @@ function routing($stateProvider) {
                                 entries
                             );
 
-                            return true;
+                            return entries;
                         }],
-                        prepare: ['view', '$stateParams', 'dataStore', '$window', function(view, $stateParams, dataStore, $window) {
-                            return view.doPrepare({
+                        prepare: ['view', '$stateParams', 'dataStore', 'entries', '$window', '$injector', function(view, $stateParams, dataStore, entries, $window, $injector) {
+                            return view.prepare() && $injector.invoke(view.prepare(), view, {
                                 query: $stateParams,
                                 datastore: dataStore,
                                 view,
                                 Entry,
+                                entries,
                                 window: $window
                             });
                         }],
@@ -219,8 +220,8 @@ function routing($stateProvider) {
                     })
                     return true;
                 }],
-                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
-                    return view.doPrepare({
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', '$injector', function(view, $stateParams, dataStore, entries, $window, $injector) {
+                    return view.prepare() && $injector.invoke(view.prepare(), view, {
                         query: $stateParams,
                         datastore: dataStore,
                         view,
@@ -228,7 +229,6 @@ function routing($stateProvider) {
                         entry,
                         window: $window
                     });
-
                 }],
             }
         });
@@ -271,8 +271,8 @@ function routing($stateProvider) {
                         ).map(entry => dataStore.addEntry(choices[name].targetEntity().uniqueId + '_choices', entry));
                     }
                 }],
-                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
-                    return view.doPrepare({
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', '$injector', function(view, $stateParams, dataStore, entries, $window, $injector) {
+                    return view.prepare() && $injector.invoke(view.prepare(), view, {
                         query: $stateParams,
                         datastore: dataStore,
                         view,
@@ -280,7 +280,6 @@ function routing($stateProvider) {
                         entry,
                         window: $window
                     });
-
                 }],
             }
         });
@@ -379,8 +378,8 @@ function routing($stateProvider) {
                     })
                     return true;
                 }],
-                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
-                    return view.doPrepare({
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', '$injector', function(view, $stateParams, dataStore, entries, $window, $injector) {
+                    return view.prepare() && $injector.invoke(view.prepare(), view, {
                         query: $stateParams,
                         datastore: dataStore,
                         view,
@@ -388,7 +387,6 @@ function routing($stateProvider) {
                         entry,
                         window: $window
                     });
-
                 }],
             }
         });
@@ -419,7 +417,7 @@ function routing($stateProvider) {
                     return view.mapEntry(rawEntry);
                 }],
                 prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
-                    return view.doPrepare({
+                    return view.prepare() && $injector.invoke(view.prepare(), view, {
                         query: $stateParams,
                         datastore: dataStore,
                         view,

--- a/src/javascripts/ng-admin/Crud/routing.js
+++ b/src/javascripts/ng-admin/Crud/routing.js
@@ -1,12 +1,12 @@
-import Entry from 'admin-config/lib/Entry';
-import DataStore from 'admin-config/lib/DataStore/DataStore';
-import listLayoutTemplate from './list/listLayout.html';
-import listTemplate from './list/list.html';
-import showTemplate from './show/show.html';
-import createTemplate from './form/create.html';
-import editTemplate from './form/edit.html';
-import deleteTemplate from './delete/delete.html';
-import batchDeleteTemplate from './delete/batchDelete.html';
+import DataStore  from 'admin-config/lib/DataStore/DataStore'
+import Entry  from 'admin-config/lib/Entry'
+import batchDeleteTemplate  from './delete/batchDelete.html'
+import deleteTemplate  from './delete/delete.html'
+import createTemplate  from './form/create.html'
+import editTemplate  from './form/edit.html'
+import listTemplate  from './list/list.html'
+import listLayoutTemplate  from './list/listLayout.html'
+import showTemplate  from './show/show.html'
 
 function templateProvider(viewName, defaultView) {
     return ['$stateParams', 'NgAdminConfiguration', function ($stateParams, Configuration) {
@@ -125,6 +125,15 @@ function routing($stateProvider) {
 
                             return true;
                         }],
+                        prepare: ['view', '$stateParams', 'dataStore', '$window', function(view, $stateParams, dataStore, $window) {
+                            return view.doPrepare({
+                                query: $stateParams,
+                                datastore: dataStore,
+                                view,
+                                Entry,
+                                window: $window
+                            });
+                        }],
                     }
                 }
             }
@@ -209,7 +218,18 @@ function routing($stateProvider) {
                         }
                     })
                     return true;
-                }]
+                }],
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
+                    return view.doPrepare({
+                        query: $stateParams,
+                        datastore: dataStore,
+                        view,
+                        Entry,
+                        entry,
+                        window: $window
+                    });
+
+                }],
             }
         });
 
@@ -250,7 +270,18 @@ function routing($stateProvider) {
                             choices[name].targetEntity().identifier().name()
                         ).map(entry => dataStore.addEntry(choices[name].targetEntity().uniqueId + '_choices', entry));
                     }
-                }]
+                }],
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
+                    return view.doPrepare({
+                        query: $stateParams,
+                        datastore: dataStore,
+                        view,
+                        Entry,
+                        entry,
+                        window: $window
+                    });
+
+                }],
             }
         });
 
@@ -347,7 +378,18 @@ function routing($stateProvider) {
                         }
                     })
                     return true;
-                }]
+                }],
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
+                    return view.doPrepare({
+                        query: $stateParams,
+                        datastore: dataStore,
+                        view,
+                        Entry,
+                        entry,
+                        window: $window
+                    });
+
+                }],
             }
         });
 
@@ -375,6 +417,17 @@ function routing($stateProvider) {
                 }],
                 entry: ['view', 'rawEntry', function(view, rawEntry) {
                     return view.mapEntry(rawEntry);
+                }],
+                prepare: ['view', '$stateParams', 'dataStore', 'entry', '$window', function(view, $stateParams, dataStore, entry, $window) {
+                    return view.doPrepare({
+                        query: $stateParams,
+                        datastore: dataStore,
+                        view,
+                        Entry,
+                        entry,
+                        window: $window
+                    });
+
                 }],
             }
         });

--- a/src/javascripts/test/e2e/ListViewSpec.js
+++ b/src/javascripts/test/e2e/ListViewSpec.js
@@ -151,4 +151,16 @@ describe('ListView', function () {
             });
         });
     });
+
+    describe('prepare', function() {
+        it('should execute after the resolve and before the controller', function() {
+            browser.get('/#/tags/list')
+                .then(function() {
+                    return $$('td.ng-admin-column-nb_posts').first();
+                })
+                .then(function(element) {
+                    expect(element.getText()).toBe('2');
+                });
+        })
+    })
 });


### PR DESCRIPTION
`view.prepare(Function)` adds a function to be executed before the view renders.

This is the ideal place to prefetch related entities and manipulate the DataStore. The function can be asynchronous, in which case it should return a Promise.

The `prepare` function is invoked using Angular's dependency injection system, with a context offering the following services:

- `query`: the query object (an object representation of the main request query string)
- `datastore`: where the Entries are stored. The dataStore is accessible during rendering
- `view`: the current View object
- `entry`: the current Entry instance (except in listView)
- `entries`: the current list of Entry instances (only in listView)
- `Entry`: the Entry constructor (required to transform an object from the REST response to an Entry)
- `window`: the window object. If you need to fetch anything other than an entry and pass it to the view layer, it's the only way.

Of course, regular Angular services (like Restangular) are also available.

```js
post.listView().prepare(['datastore', 'entries', 'Entry', function(datastore, entries, Entry ) {
  const authorIds = entries.map(post => post.values.authorId).join(',');
  return fetch('http://myapi.com/authors?id[]=' + authorIds)
     .then(response => response.json())
     .then(authors => Entry.createArrayFromRest(
         authors,
         [new Field('first_name'), new Field('last_name')],
         'author'
     ))
     .then(authorEntries => datastore.setEntries('authors', authorEntries));
}])
```

- [x] Add call to `prepare()` in routing
- [x] Document usage
- [x] Add working example
- [x] Add tests