### PR TITLE
Possibility to add Create action Button for any entity  and fixes Bug

### DIFF
--- a/src/javascripts/ng-admin/Crud/button/maCreateButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maCreateButton.js
@@ -18,10 +18,10 @@ export default function maCreateButtonDirective($state) {
             scope.gotoCreate = () => {
                 var entityName;
                 if (attrs.force === "true"){
-                  entityName = attrs.entityName;
+                  entityName = attrs.entity;
                 }
                 else {
-                  entityName = scope.entity() ? scope.entity().name() : attrs.entityName;
+                  entityName = scope.entity() ? scope.entity().name() : attrs.entity;
                 }
                 var params = entityName === $state.params.entity ? $state.params : {};
                 params.entity = entityName;

--- a/src/javascripts/ng-admin/Crud/button/maCreateButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maCreateButton.js
@@ -16,8 +16,14 @@ export default function maCreateButtonDirective($state) {
         },
         link: function (scope, element, attrs) {
             scope.gotoCreate = () => {
-                var entityName = scope.entity() ? scope.entity().name() : attrs.entityName;
-                var params = entityName == $state.params.entity ? $state.params : {};
+                var entityName;
+                if (attrs.force === "true"){
+                  entityName = attrs.entityName;
+                }
+                else {
+                  entityName = scope.entity() ? scope.entity().name() : attrs.entityName;
+                }
+                var params = entityName === $state.params.entity ? $state.params : {};
                 params.entity = entityName;
                 params.defaultValues = scope.defaultValues();
                 $state.go($state.get('create'), params);


### PR DESCRIPTION
This adds the option, to add a button which allows to specify the entity for which the create view should be done.

If this functionality isnt useful for a broader audience this still fixes a bug where attrs.entityName is called when it should be attrs.entity.
