### PR TITLE
controlling choices dropdown position - workaround #780

### DIFF
--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -156,7 +156,7 @@
                     .choices([ // List the choice as object literals
                         { label: 'Tech', value: 'tech' },
                         { label: 'Lifestyle', value: 'lifestyle' }
-                    ]),
+                    ]).attributes({ position: 'down' }),
                 nga.field('subcategory', 'choice')
                     .choices(function(entry) { // choices also accepts a function to return a list of choices based on the current entry
                         return subCategories.filter(function (c) {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "style-loader": "^0.12.2",
     "superagent": "^0.18.2",
     "textangular": "1.4.3",
-    "ui-select": "angular-ui/ui-select#271bf6a03078587c5afdb05f61e826573a13d348",
+    "ui-select": "angular-ui/ui-select#v0.13.2",
     "underscore": "^1.8.3",
     "url-loader": "^0.5.5",
     "webpack": "^1.10.0",

--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -38,11 +38,12 @@ export default function maChoiceField($compile) {
                     var choices = (typeof scope.choices == 'function' && scope.choices()) ? scope.choices() : (field.choices ? field.choices() : []);
                     var attributes = field.attributes();
                     scope.placeholder = (attributes && attributes.placeholder) || 'Filter values';
+                    scope.dropdownPosition = (attributes && attributes.position) || 'auto';
 
                     var template = `
                         <ui-select ng-model="$parent.value" ng-required="v.required" id="{{ name }}" name="{{ name }}">
                             <ui-select-match allow-clear="{{ !v.required }}" placeholder="{{ placeholder }}">{{ $select.selected.label }}</ui-select-match>
-                            <ui-select-choices ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter}  track by $index">
+                            <ui-select-choices position="{{ dropdownPosition }}" ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter} track by $index">
                                 {{ item.label }}
                             </ui-select-choices>
                         </ui-select>`;

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -33,11 +33,12 @@ export default function maChoicesField($compile) {
                     var choices = field.choices ? field.choices() : [];
                     var attributes = field.attributes();
                     scope.placeholder = (attributes && attributes.placeholder) || 'Filter values';
+                    scope.dropdownPosition = (attributes && attributes.position) || 'auto';
 
                     var template = `
                         <ui-select ${scope.v.required ? 'ui-select-required' : ''} multiple ng-model="$parent.value" ng-required="v.required" id="{{ name }}" name="{{ name }}">
                             <ui-select-match placeholder="{{ placeholder }}">{{ $item.label }}</ui-select-match>
-                            <ui-select-choices ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter}">
+                            <ui-select-choices position="{{ dropdownPosition }}" ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter}">
                                 {{ item.label }}
                             </ui-select-choices>
                         </ui-select>`;


### PR DESCRIPTION
using newer ui-select, and allowing the user to pass position values to it's ui-select-choices to control the position of the dropdown. There are a few bugs in ui-select for when it opens up (e.g. when there's not enough room for it to open up), and allowing the user to set position:"down" would work around this (you can almost always scroll down, or add padding to allow for it, but not up).