### PR TITLE
[RFR] Allow boolean filter labels to be overridden

### DIFF
--- a/doc/reference/Field.md
+++ b/doc/reference/Field.md
@@ -12,7 +12,7 @@ A field is the representation of a property of an entity.
 * [`datetime` Field Type](#-datetime-field-type)
 * [`number` Field Type](#-number-field-type)
 * `float` Field Type
-* `boolean` Field Type
+* [`boolean` Field Type](#-boolean-field-type)
 * [`choice` and `choices` Field Types](#-choice-and-choices-field-types)
 * `json` Field Type
 * [`file` Field Type](#-file-field-type)
@@ -232,6 +232,22 @@ Array of choices used for the boolean values. By default:
                 { value: true, label: 'enabled' },
                 { value: false, label: 'disabled' }
             ]);
+
+* `filterChoices(array)`
+Array of choices used for the boolean proposed values in a filter. By default:
+
+        [
+            { value: true, label: 'true' },
+            { value: false, label: 'false' }
+        ]
+
+    Override it with custom labels to fit your needs:
+
+    nga.fields('power_user', 'boolean')
+        .filterChoices([
+            { value: true, label: 'enabled' },
+            { value: false, label: 'disabled' }
+        ]);
 
 ## `choice` and `choices` Field Types
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.7.1",
+    "admin-config": "^0.8.0",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
+++ b/src/javascripts/ng-admin/Crud/fieldView/BooleanFieldView.js
@@ -1,7 +1,7 @@
 export default {
     getReadWidget:   () => '<ma-boolean-column value="::value"></ma-boolean-column>',
     getLinkWidget:   () => '<a ui-sref="{{detailState}}(detailStateParams)">' + module.exports.getReadWidget() + '</a>',
-    getFilterWidget: () => `<ma-choice-field field="::field" value="value" choices="[{value: 'true', label: 'true' }, { value: 'false', label: 'false' }]"></ma-choice-field>`,
+    getFilterWidget: () => `<ma-choice-field field="::field" value="value" choices="::field.filterChoices()"></ma-choice-field>`,
     getWriteWidget:  () => `<div class="row">
         <ma-choice-field class="col-sm-4 col-md-3" ng-if="!field.validation().required" field="::field" value="$parent.value"></ma-choice-field>
         <ma-checkbox-field class="col-sm-4 col-md-3" ng-if="!!field.validation().required" field="::field" value="$parent.value"></ma-checkbox-field>

--- a/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
@@ -95,7 +95,7 @@ export default class ListLayoutController {
                 continue;
             }
 
-            if ((field.type() === 'boolean' && this.search[fieldName]) || // for boolean false is the same as null
+            if ((field.type() === 'boolean' && fieldName in this.search) || // for boolean false is the same as null
                 (field.type() !== 'boolean' && this.search[fieldName] !== null)) {
                 values[fieldName] = field.getTransformedValue(this.search[fieldName]);
             }

--- a/src/javascripts/test/unit/Crud/fieldView/BooleanFieldView.js
+++ b/src/javascripts/test/unit/Crud/fieldView/BooleanFieldView.js
@@ -19,7 +19,7 @@ describe('BooleanFieldView', function() {
     describe('getFilterWidget', function() {
         it('should return choice field directive with true and false choices', function() {
             var widget = BooleanFieldView.getFilterWidget();
-            assert.match(widget, /<ma-choice-field .* choices="\[{value: \'true\', label: \'true\' }, { value: \'false\', label: \'false\' }]"/);
+            assert.match(widget, /<ma-choice-field .* choices="::field\.filterChoices\(\)"/);
         });
     });
 


### PR DESCRIPTION
For `boolean` Field Type, add the `filterChoices(array)` method. It expects an array of choices used for the boolean proposed values in a filter. By default:

        [
            { value: true, label: 'true' },
            { value: false, label: 'false' }
        ]

Override it with custom labels to fit your needs:

    nga.fields('power_user', 'boolean')
        .filterChoices([
            { value: true, label: 'enabled' },
            { value: false, label: 'disabled' }
        ]);