### PR TITLE
workaround ng 1.3.20 bug with filterless track by on choice field

### DIFF
--- a/src/javascripts/ng-admin/Crud/field/maChoiceField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoiceField.js
@@ -32,7 +32,9 @@ export default function maChoiceField($compile) {
                     if (field.type().indexOf('reference') === 0 && field.remoteComplete()) { // FIXME wrong place to do that
                         scope.refreshDelay = field.remoteCompleteOptions().refreshDelay;
                         refreshAttributes = 'refresh-delay="refreshDelay" refresh="refresh({ $search: $select.search })"';
-                        itemsFilter = '';
+                        // workaround ngadmin 1.3.x bug, see https://github.com/angular-ui/ui-select/issues/1233
+                        itemsFilter = '| filter: noopFilter';
+                        scope.noopFilter = () => true;
                     }
 
                     var choices = (typeof scope.choices == 'function' && scope.choices()) ? scope.choices() : (field.choices ? field.choices() : []);
@@ -42,7 +44,7 @@ export default function maChoiceField($compile) {
                     var template = `
                         <ui-select ng-model="$parent.value" ng-required="v.required" id="{{ name }}" name="{{ name }}">
                             <ui-select-match allow-clear="{{ !v.required }}" placeholder="{{ placeholder }}">{{ $select.selected.label }}</ui-select-match>
-                            <ui-select-choices ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter}  track by $index">
+                            <ui-select-choices ${refreshAttributes} repeat="item.value as item in choices ${itemsFilter} track by $index">
                                 {{ item.label }}
                             </ui-select-choices>
                         </ui-select>`;

--- a/src/javascripts/ng-admin/Crud/field/maChoicesField.js
+++ b/src/javascripts/ng-admin/Crud/field/maChoicesField.js
@@ -27,7 +27,9 @@ export default function maChoicesField($compile) {
                     if (field.type().indexOf('reference') === 0 && field.remoteComplete()) {
                         scope.refreshDelay = field.remoteCompleteOptions().refreshDelay;
                         refreshAttributes = 'refresh-delay="refreshDelay" refresh="refresh({ $search: $select.search })"';
-                        itemsFilter = '';
+                        // workaround ngadmin 1.3.x bug, see https://github.com/angular-ui/ui-select/issues/1233
+                        itemsFilter = '| filter: noopFilter';
+                        scope.noopFilter = () => true;
                     }
 
                     var choices = field.choices ? field.choices() : [];


### PR DESCRIPTION
choice field, with remoteComplete, causes ng-admin to freak out with 'unexpected token "track"', see see https://github.com/angular-ui/ui-select/issues/1233

the workaround is to put in a noop filter, at least while 1.3 is supported.