### PR TITLE
Fix ng-admin issue #738

### DIFF
--- a/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
@@ -4,8 +4,7 @@ export default function maExportToCsvButton ($stateParams, Papa, notification, A
         scope: {
             entity: '&',
             label: '@',
-            datastore: '&',
-            search: '&'
+            datastore: '&'
         },
         link: function(scope) {
             scope.label = scope.label || 'Export';
@@ -30,7 +29,7 @@ export default function maExportToCsvButton ($stateParams, Papa, notification, A
                 var nonOptimizedReferencedData;
                 var optimizedReferencedData;
 
-                ReadQueries.getAll(exportView, -1, scope.search(), $stateParams.sortField, $stateParams.sortDir)
+                ReadQueries.getAll(exportView, -1, $stateParams.search, $stateParams.sortField, $stateParams.sortDir)
                     .then(response => {
                         rawEntries = response.data;
                         return rawEntries;

--- a/src/javascripts/ng-admin/Crud/show/maShowItem.js
+++ b/src/javascripts/ng-admin/Crud/show/maShowItem.js
@@ -23,8 +23,10 @@ export default function maShowItem() {
         template:
 `<div class="col-lg-12 form-group">
     <label class="col-sm-2 control-label">{{ field.label() }}</label>
-    <div class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + 'ng-admin-type-' + field.type() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
-        <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+    <div class="show-value" ng-class="(field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
+        <div ng-class="::'ng-admin-field-' + field.name() + ' ' + 'ng-admin-type-' + field.type()">
+            <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+        </div>
     </div>
 </div>`
     };


### PR DESCRIPTION
exportToCsv function was failing to correctly (re)load data in a new filtered page.
This was due to an incorrect search parameters given to the ReadQueries getAll function. Using $stateParams' search attribute (instead of scope.search()) solves the issue.

As a bonus a minor fix:
Use separate block to specify CSS classes in show item view.
This is required to cope with a bug found in webkit-based browsers (e.g. Chrome, Safari) which produced a corrupt highlighted text upon both double-click and triple-click selection.