### PR TITLE
Reload export data when list is (re)filtered

### DIFF
--- a/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
@@ -4,8 +4,7 @@ export default function maExportToCsvButton ($stateParams, Papa, notification, A
         scope: {
             entity: '&',
             label: '@',
-            datastore: '&',
-            search: '&'
+            datastore: '&'
         },
         link: function(scope) {
             scope.label = scope.label || 'Export';
@@ -30,7 +29,7 @@ export default function maExportToCsvButton ($stateParams, Papa, notification, A
                 var nonOptimizedReferencedData;
                 var optimizedReferencedData;
 
-                ReadQueries.getAll(exportView, -1, scope.search(), $stateParams.sortField, $stateParams.sortDir)
+                ReadQueries.getAll(exportView, -1, $stateParams.search, $stateParams.sortField, $stateParams.sortDir)
                     .then(response => {
                         rawEntries = response.data;
                         return rawEntries;

--- a/src/javascripts/ng-admin/Crud/list/listLayout.html
+++ b/src/javascripts/ng-admin/Crud/list/listLayout.html
@@ -5,7 +5,7 @@
             <ma-view-actions override="::llCtrl.actions" selection="selection" batch-buttons="::llCtrl.batchActions" entity="::llCtrl.entity" datastore="::llCtrl.dataStore" search="::llCtrl.search" filters="::llCtrl.filters" enabled-filters="llCtrl.enabledFilters" enable-filter="llCtrl.enableFilter">
                 <ma-filter-button filters="filters()" enabled-filters="enabledFilters" enable-filter="enableFilter()"></ma-filter-button>
                 <ma-view-batch-actions buttons="::batchButtons()" selection="selection" entity="::entity"></ma-view-batch-actions>
-                <ma-export-to-csv-button entity="::entity" search="::search" datastore="::datastore"></ma-export-to-csv-button>
+                <ma-export-to-csv-button entity="::entity" datastore="::datastore"></ma-export-to-csv-button>
                 <ma-create-button ng-if="::entity.creationView().enabled" entity="::entity"></ma-create-button>
             </ma-view-actions>
 

--- a/src/javascripts/ng-admin/Crud/misc/ViewActions.js
+++ b/src/javascripts/ng-admin/Crud/misc/ViewActions.js
@@ -44,7 +44,7 @@ export default function ViewActions($injector) {
     <ma-show-button ng-switch-when="show" entry="entry" entity="entity"></ma-show-button>
     <ma-edit-button ng-switch-when="edit" entry="entry" entity="entity"></ma-edit-button>
     <ma-delete-button ng-switch-when="delete" entry="entry" entity="entity"></ma-delete-button>
-    <ma-export-to-csv-button ng-switch-when="export" datastore="datastore" entity="entity" search="search"></ma-export-to-csv-button>
+    <ma-export-to-csv-button ng-switch-when="export" datastore="datastore" entity="entity"></ma-export-to-csv-button>
     <span ng-switch-default><span compile="button"></span></span>
 </span>`
     };


### PR DESCRIPTION
exportToCsv function was failing to correctly reload data in a new filtered page. This was due to an incorrect search parameters given to the ReadQueries getAll function. Using $stateParams' search
attribute (instead of scope.search()) solves the issue.

Fix ng-admin issue #738.