### PR TITLE
Fix double-click selection bug in webkit browsers

### DIFF
--- a/src/javascripts/ng-admin/Crud/show/maShowItem.js
+++ b/src/javascripts/ng-admin/Crud/show/maShowItem.js
@@ -23,8 +23,10 @@ export default function maShowItem() {
         template:
 `<div class="col-lg-12 form-group">
     <label class="col-sm-2 control-label">{{ field.label() }}</label>
-    <div class="show-value" ng-class="::'ng-admin-field-' + field.name() + ' ' + 'ng-admin-type-' + field.type() + ' ' + (field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
-        <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+    <div class="show-value" ng-class="(field.getCssClasses(entry) || 'col-sm-10 col-md-8 col-lg-7')">
+        <div ng-class="::'ng-admin-field-' + field.name() + ' ' + 'ng-admin-type-' + field.type()">
+            <ma-column field="::field" entry="::entry" entity="::entity" datastore="::datastore"></ma-column>
+        </div>
     </div>
 </div>`
     };


### PR DESCRIPTION
Use separate block to specify CSS classes in show item view.
This is required to cope with a bug found in webkit-based browsers (e.g. Chrome, Safari) which produced a corrupt highlighted text upon both double-click and triple-click selection.