### PR TITLE
[POC] Add creation & edition events

### DIFF
--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -181,3 +181,32 @@ entity.errorMessage(function (response) {
     return 'Global error: ' + response.status + '(' + response.data + ')';
 });
 ```
+
+## Events
+
+Some events are available when creating or updating an entity :
+
+- `ng-admin.creation.success`
+- `ng-admin.creation.error`
+- `ng-admin.edition.success`
+- `ng-admin.edition.error`
+
+Example :
+
+```js
+angular.module('my_module', [])
+    .run(function($rootScope) {
+        $rootScope.$on('ng-admin.edition.error', function(event, args) {
+            if (angular.isUndefined(args.response.data.violations)) {
+                return;
+            }
+
+            var form = event.targetScope.formController.form;
+            angular.forEach(args.response.data.violations, function(violation) {
+                if (angular.isDefined(form[violation.propertyPath])) {
+                    form[violation.propertyPath].$valid = false;
+                }
+            });
+        });
+    });
+```

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -52,11 +52,15 @@ export default class FormController {
         this.WriteQueries
             .createOne(view, restEntry)
             .then(rawEntry => {
+                this.$scope.$emit('ng-admin.creation.success', {sentRestEntry: restEntry, newRestEntry: rawEntry});
                 this.progression.done();
                 this.notification.log('Element successfully created.', { addnCls: 'humane-flatty-success' });
                 var entry = view.mapEntry(rawEntry);
                 this.$state.go(this.$state.get(route), { entity: entity.name(), id: entry.identifierValue });
-            }, this.handleError.bind(this));
+            }, response => {
+                this.$scope.$emit('ng-admin.creation.error', {sentRestEntry: restEntry, response: response});
+                this.handleError(response);
+            });
     }
 
     submitEdition($event) {
@@ -69,10 +73,14 @@ export default class FormController {
         this.progression.start();
         this.WriteQueries
             .updateOne(view, restEntry, this.originEntityId)
-            .then(() => {
+            .then(updatedRestEntry => {
+                this.$scope.$emit('ng-admin.edition.success', {sentRestEntry: restEntry, updatedRestEntry: updatedRestEntry});
                 this.progression.done();
                 this.notification.log('Changes successfully saved.', { addnCls: 'humane-flatty-success' });
-            }, this.handleError.bind(this));
+            }, response => {
+                this.$scope.$emit('ng-admin.edition.error', {sentRestEntry: restEntry, response: response});
+                this.handleError(response);
+            });
     }
 
     /**


### PR DESCRIPTION
Hi,

While using ng-admin, I've found two limits for my needs :

- I've not found an easy way to mark a field as invalid after API POST or PUT call (the API 400 response contains violations)
- After an entity update, if the API has updated a field (slug generation for example), the new values returned by the call are not set in the entity (there is a `transformToRest`, but no `updateToRest` method call in the [submitEdition](https://github.com/marmelab/ng-admin/blob/master/src/javascripts/ng-admin/Crud/form/FormController.js#L62) method.

In order to fix this problems, we can use a `updateToRest` method [here](https://github.com/marmelab/ng-admin/blob/master/src/javascripts/ng-admin/Crud/form/FormController.js#L72) and add a `handleCustomError` [here](https://github.com/marmelab/ng-admin/blob/master/src/javascripts/ng-admin/Crud/form/FormController.js#L83), or we can add some events in the `FormController` and let the developer do what it wants. 

This PR is a POC, what do you think about the event usage ?