### PR TITLE
Update ui-select version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "style-loader": "^0.12.2",
     "superagent": "^0.18.2",
     "textangular": "1.4.3",
-    "ui-select": "angular-ui/ui-select#271bf6a03078587c5afdb05f61e826573a13d348",
+    "ui-select": "^0.13",
     "underscore": "^1.8.3",
     "url-loader": "^0.5.5",
     "webpack": "^1.10.0",


### PR DESCRIPTION
This PR fixes ui-select bugs by using the last version (0.13.2).

For example : the https://github.com/angular-ui/ui-select/pull/836 PR add some display bugs like https://github.com/angular-ui/ui-select/issues/1007 . The last version fixes this.

CAUTION : see the next comment