### PR TITLE
add undefined filtering to remove console errors due to null or empty…

### DIFF
--- a/doc/API-mapping.md
+++ b/doc/API-mapping.md
@@ -110,6 +110,8 @@ myApp.config(['RestangularProvider', function(RestangularProvider) {
 }]);
 ```
 
+*IE9 doesn't support the ```window.bota()``` method, use a polyfill to extend support. (https://github.com/davidchambers/Base64.js/)*
+
 ## HTTP Method
 
 The REST standard suggests using the POST method to create a new resource, and PUT to update it. If your API uses a different verb for a given action (e.g. PATCH), then you can force the method to be used for a given entity with `createMethod()` and `updateMethod()`.

--- a/src/javascripts/ng-admin/Crud/column/maColumn.js
+++ b/src/javascripts/ng-admin/Crud/column/maColumn.js
@@ -54,8 +54,8 @@ export default function maColumn($state, $anchorScroll, $compile, Configuration,
             scope.detailState = getDetailLinkRouteName(scope.field, scope.entity);
             scope.detailStateParams = {
                 ...$state.params,
-                entity: scope.entry.entityName,
-                id: scope.entry.identifierValue,
+                entity: scope.entry === undefined ? '' : scope.entry.entityName,
+                id: scope.entry === undefined ? '' : scope.entry.identifierValue,
             };
             $compile(element.contents())(scope);
         }


### PR DESCRIPTION
… reference on showView

Not sure if this is the correct way to suppress undefined warnings, but it works.