### PR TITLE
[RFR] Fix webpack-dev-server web-socket error

### DIFF
--- a/examples/blog/fakerest-init.js
+++ b/examples/blog/fakerest-init.js
@@ -15,7 +15,7 @@
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter(function (method, url) {
         // Do not catch webpack sync, config.js transformation but catch /upload in test env
-        return url.indexOf('/socket.io/') !== -1 || url.indexOf('config.js') !== -1
+        return url.indexOf('/sockjs-node/') !== -1 || url.indexOf('config.js') !== -1
             || (!testEnv && url.indexOf('/upload') !== -1);
     });
 


### PR DESCRIPTION
When I'm doing `make run` -  my Chromium devTools Console got flooded by "[WDS] Disconnected!" messages sent within interval of 2 seconds.
I've investigated the issue and found out that the problem is caused by `SinonJS` which intercepts WebSocket requests to `webpack-dev-server`. This is because `webpack-dev-server` recently [moved from Socket.io to SockJS](https://github.com/webpack/webpack-dev-server/pull/302), so now WebSocket requests are sent  not to `/socket.io/` path, but to the `/sockjs-node/` path.