### PR TITLE
[RFR] Add ability to customize CSV export format

### DIFF
--- a/doc/reference/View.md
+++ b/doc/reference/View.md
@@ -174,6 +174,14 @@ Set the fields for the CSV export function. By default, ng-admin uses the fields
                 .stripTags(true)
         ]);
 
+* `exportOptions(Object)`
+Customize the CSV export format (quotes, delimiter, newline). The default options object is `{ quotes: false, delimiter: ",", newline: "\r\n" }`.
+
+        listView.exportOptions({
+            quotes: true,
+            delimiter: ';'
+        });
+
 * `prepare(Function)`
 Add a function to be executed before the view renders.
 

--- a/examples/blog/config.js
+++ b/examples/blog/config.js
@@ -138,6 +138,24 @@
             .listActions(['show', 'edit', 'delete'])
             .entryCssClasses(function(entry) { // set row class according to entry
                 return (entry.views > 300) ? 'is-popular' : '';
+            })
+            .exportFields([
+                post.listView().fields(), // fields() without arguments returns the list of fields. That way you can reuse fields from another view to avoid repetition
+                nga.field('category', 'choice') // a choice field is rendered as a dropdown in the edition view
+                    .choices([ // List the choice as object literals
+                        { label: 'Tech', value: 'tech' },
+                        { label: 'Lifestyle', value: 'lifestyle' }
+                    ]),
+                nga.field('subcategory', 'choice')
+                    .choices(function(entry) { // choices also accepts a function to return a list of choices based on the current entry
+                        return subCategories.filter(function (c) {
+                            return c.category === entry.values.category;
+                        });
+                    }),
+            ])
+            .exportOptions({
+                quotes: true,
+                delimiter: ';'
             });
 
         post.creationView()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.10.0",
+    "admin-config": "^0.11.0",
     "angular": "~1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-mocks": "1.3.14",

--- a/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
+++ b/src/javascripts/ng-admin/Crud/button/maExportToCsvButton.js
@@ -54,7 +54,7 @@ export default function maExportToCsvButton ($stateParams, Papa, notification, A
                         for (var i = entries.length - 1; i >= 0; i--) {
                             results[i] = formatEntry(entries[i]);
                         }
-                        var csv = Papa.unparse(results);
+                        var csv = Papa.unparse(results, listView.exportOptions());
                         var fakeLink = document.createElement('a');
                         document.body.appendChild(fakeLink);
 


### PR DESCRIPTION
Customize the CSV export format (quotes, delimiter, newline). The default options object is `{ quotes: false, delimiter: ",", newline: "\r\n" }`.

        listView.exportOptions({
            quotes: true,
            delimiter: ';'
        });