### PR TITLE
fixing frontend pagination typo from '1-10 on 15' to '1-10 of 15'

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/maDatagridPagination.html
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridPagination.html
@@ -1,7 +1,7 @@
 <nav class="pagination-bar">
 
     <div class="total" ng-if="paginationCtrl.totalItems > 0">
-        <strong>{{ paginationCtrl.offsetBegin }}</strong> - <strong>{{ paginationCtrl.offsetEnd }}</strong> on <strong>{{ paginationCtrl.totalItems }}</strong>
+        <strong>{{ paginationCtrl.offsetBegin }}</strong> - <strong>{{ paginationCtrl.offsetEnd }}</strong> of <strong>{{ paginationCtrl.totalItems }}</strong>
     </div>
 
     <div class="total no-record" ng-if="paginationCtrl.totalItems == 0">

--- a/src/javascripts/test/unit/Crud/list/maDatagridPaginationSpec.js
+++ b/src/javascripts/test/unit/Crud/list/maDatagridPaginationSpec.js
@@ -38,13 +38,13 @@ describe('directive: ma-datagrid-pagination', function () {
                 expect(totalElement.innerText.trim()).toBe(expectedText);
             }
 
-            checkTotalText(-1, '1 - 10 on 37');     // Lower pages should be considered as page 1
-            checkTotalText( 0, '1 - 10 on 37');
-            checkTotalText( 1, '1 - 10 on 37');
-            checkTotalText( 2, '11 - 20 on 37');
-            checkTotalText( 3, '21 - 30 on 37');
-            checkTotalText( 4, '31 - 37 on 37');
-            checkTotalText( 8, '31 - 37 on 37');    // Higher pages should be considered as last page
+            checkTotalText(-1, '1 - 10 of 37');     // Lower pages should be considered as page 1
+            checkTotalText( 0, '1 - 10 of 37');
+            checkTotalText( 1, '1 - 10 of 37');
+            checkTotalText( 2, '11 - 20 of 37');
+            checkTotalText( 3, '21 - 30 of 37');
+            checkTotalText( 4, '31 - 37 of 37');
+            checkTotalText( 8, '31 - 37 of 37');    // Higher pages should be considered as last page
         });
     });
 


### PR DESCRIPTION
I noticed what I believe to be a typo in the text on the frontend which specifies what items are being shown and the total amount of items. Currently the pagination area reads something like "1-10 on 15" when I think it should be "1-10 **of** 15." I updated the frontend code and the testing files to this effect.