### PR TITLE
[RFR] Update ui-bootstrap

### DIFF
--- a/doc/Production.md
+++ b/doc/Production.md
@@ -22,8 +22,7 @@ Here is a snippet showing all required scripts:
 <link rel="stylesheet" href="node_modules/ng-admin/build/ng-admin-only.min.css" />
 
 <script src="node_modules/angular/angular.js"></script>
-<script src="node_modules/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
-<script src="node_modules/angular-bootstrap/ui-bootstrap.min.js"></script>
+<script src="node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>
 <script src="node_modules/angular-resource/angular-resource.min.js"></script>
 <script src="node_modules/angular-sanitize/angular-sanitize.min.js"></script>
 <script src="node_modules/angular-ui-codemirror/ui-codemirror.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "devDependencies": {
     "admin-config": "^0.11.0",
     "angular": "~1.4.8",
-    "angular-bootstrap": "^0.12.0",
     "angular-mocks": "~1.4.8",
     "angular-numeraljs": "^1.1.6",
     "angular-sanitize": "^1.3.15",
+    "angular-ui-bootstrap": "^1.0.0",
     "angular-ui-codemirror": "^0.3.0",
     "angular-ui-router": "^0.2.14",
     "angularjs": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "angular-mocks": "~1.4.8",
     "angular-numeraljs": "^1.1.6",
     "angular-sanitize": "^1.3.15",
-    "angular-ui-bootstrap": "^1.0.0",
+    "angular-ui-bootstrap": "~1.2.1",
     "angular-ui-codemirror": "^0.3.0",
     "angular-ui-router": "^0.2.14",
     "angularjs": "0.0.1",

--- a/src/javascripts/ng-admin/Crud/CrudModule.js
+++ b/src/javascripts/ng-admin/Crud/CrudModule.js
@@ -21,7 +21,7 @@ CrudModule.service('RestWrapper', require('./misc/RestWrapper'));
 
 CrudModule.directive('maJsonValidator', require('./validator/maJsonValidator'));
 
-CrudModule.directive('datepickerPopup', require('./field/datepickerPopup'));
+CrudModule.directive('uibDatepickerPopup', require('./field/datepickerPopup'));
 CrudModule.directive('maField', require('./field/maField'));
 CrudModule.directive('maButtonField', require('./field/maButtonField'));
 CrudModule.directive('maChoiceField', require('./field/maChoiceField'));

--- a/src/javascripts/ng-admin/Crud/button/maViewBatchActions.js
+++ b/src/javascripts/ng-admin/Crud/button/maViewBatchActions.js
@@ -23,7 +23,7 @@ export default function maViewBatchActionsDirective() {
         },
         // the ng-class hidden is necessary to hide the inner blank space used for spacing buttons when the selection is not empty
         template:
-`<span ng-if="selection" ng-class="{hidden:!selection || selection.length==0}"> <span class="btn-group" dropdown is-open="isopen"><button type="button" ng-if="selection.length" class="btn btn-default dropdown-toggle" dropdown-toggle >
+`<span ng-if="selection" ng-class="{hidden:!selection || selection.length==0}"> <span class="btn-group" uib-dropdown is-open="isopen"><button type="button" ng-if="selection.length" class="btn btn-default dropdown-toggle" uib-dropdown-toggle >
             {{ selection.length }} Selected <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu">

--- a/src/javascripts/ng-admin/Crud/field/datepickerPopup.js
+++ b/src/javascripts/ng-admin/Crud/field/datepickerPopup.js
@@ -1,12 +1,13 @@
 /**
  * Fixes an issue with Bootstrap Date Picker
  * @see https://github.com/angular-ui/bootstrap/issues/2659
+ * @see https://github.com/angular-ui/bootstrap/pull/4062
  *
  * How does it work? AngularJS allows multiple directives with the same name,
  * and each is treated independently though they are instantiated based on the
  * same element/attribute/comment.
  *
- * So this directive goes along with ui.bootstrap's datepicker-popup directive.
+ * So this directive goes along with ui.bootstrap's uib-datepicker-popup directive.
  * @see http://angular-ui.github.io/bootstrap/versioned-docs/0.12.0/#/datepicker
  */
 export default function datepickerPopup() {
@@ -14,6 +15,9 @@ export default function datepickerPopup() {
         restrict: 'EAC',
         require: 'ngModel',
         link: function(scope, element, attr, controller) {
+            // 'new Date' fallback
+            scope.value = scope.value instanceof Date ? scope.value:new Date(scope.value);
+
             //remove the default formatter from the input directive to prevent conflict
             controller.$formatters.shift();
         }

--- a/src/javascripts/ng-admin/Crud/field/maDateField.js
+++ b/src/javascripts/ng-admin/Crud/field/maDateField.js
@@ -39,7 +39,7 @@ export default function maDateField() {
 `<div class="input-group datepicker">
     <input
         type="text" ng-model="rawValue" id="{{ name }}" name="{{ name }}" class="form-control"
-        datepicker-popup="{{ format }}" is-open="isOpen" close-text="Close" ng-required="v.required" />
+        uib-datepicker-popup="{{ format }}" is-open="isOpen" close-text="Close" ng-required="v.required" />
     <span class="input-group-btn">
         <button type="button" class="btn btn-default" ng-click="toggleDatePicker($event)">
             <i class="glyphicon glyphicon-calendar"></i>

--- a/src/javascripts/ng-admin/Crud/filter/maFilterButton.js
+++ b/src/javascripts/ng-admin/Crud/filter/maFilterButton.js
@@ -13,8 +13,8 @@ export default function maFilterButton() {
             scope.hasFilters = () => scope.notYetEnabledFilters().length > 0;
         },
         template:
-`<span class="btn-group" dropdown is-open="isopen" ng-if="hasFilters()">
-    <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle >
+`<span class="btn-group" uib-dropdown is-open="isopen" ng-if="hasFilters()">
+    <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle >
         <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>&nbsp;<span class="hidden-xs">Add filter </span><span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">

--- a/src/javascripts/test/karma.conf.js
+++ b/src/javascripts/test/karma.conf.js
@@ -13,8 +13,7 @@ module.exports = function (config) {
         frameworks: ['jasmine'],
         files: [
             '../../node_modules/angular/angular.js',
-            '../../node_modules/angular-bootstrap/ui-bootstrap.min.js',
-            '../../node_modules/angular-bootstrap/ui-bootstrap-tpls.min.js',
+            '../../node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js',
             '../../node_modules/angular-mocks/angular-mocks.js',
             '../../node_modules/angular-numeraljs/dist/angular-numeraljs.min.js',
             '../../node_modules/numeral/numeral.js',

--- a/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
@@ -44,7 +44,7 @@ describe('directive: date-field', function() {
         scope.value = date;
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
-        expect(element.find('input').eq(0).attr('datepicker-popup')).toBe('yyyy-MM');
+        expect(element.find('input').eq(0).attr('uib-datepicker-popup')).toBe('yyyy-MM');
     });
 
     it("should add any supplied attribute", function () {

--- a/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maDateFieldSpec.js
@@ -55,9 +55,9 @@ describe('directive: date-field', function() {
     });
 
     it("should contain the bounded value", function () {
+        var now = '2015-04-05';
+        scope.value = new Date(now);
         scope.field = new DateField();
-        var now = '2015-03-05';
-        scope.value = now;
         var element = $compile(directiveUsage)(scope);
         scope.$digest();
         expect(element.find('input').eq(0).val()).toBe(now);

--- a/src/javascripts/vendors.js
+++ b/src/javascripts/vendors.js
@@ -10,8 +10,7 @@ require('textangular');
 require('ui-select');
 
 require('../../node_modules/angular-numeraljs/dist/angular-numeraljs');
-require('angular-bootstrap/ui-bootstrap');
-require('angular-bootstrap/ui-bootstrap-tpls');
+require('angular-ui-bootstrap/dist/ui-bootstrap-tpls');
 require('../../node_modules/ng-file-upload/dist/ng-file-upload');
 
 global._ = require('underscore');


### PR DESCRIPTION
 - [x] Update ui-boostrap to v1.2.1 now that ng-admin uses angular 1.4 (from https://github.com/marmelab/ng-admin/pull/887)
 - [x] Test `$uibModal` (from issue https://github.com/marmelab/ng-admin/issues/922) / it's tested on the ng-admin demo https://github.com/marmelab/ng-admin-demo/pull/17