### PR TITLE
Reuse sortName for sorting by arbitrary fields.

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/maDatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridController.js
@@ -64,7 +64,11 @@ export default class DatagridController {
      * @returns {String}
      */
     getSortName(field) {
-        return this.$scope.name ? this.$scope.name + '.' + field.name() : field.name();
+        var sortFieldName = field.name();
+        if(field.sortField) {
+            sortFieldName = field.sortField();
+        }
+        return this.$scope.name ? this.$scope.name + '.' + sortFieldName : sortFieldName;
     }
 
     getEntryCssClasses(entry) {


### PR DESCRIPTION
As mentioned in #851, this allows for sorting by arbitrary field names. 
