### PR TITLE
#372 allow sortable(false) on fields in list view

### DIFF
--- a/doc/API-mapping.md
+++ b/doc/API-mapping.md
@@ -205,6 +205,8 @@ myApp.config(['RestangularProvider', function(RestangularProvider) {
 }]);
 ```
 
+(If a column is not sortable by your backend, e.g. a computed column, you can disable sorting per-column using [`Field.sortable(false)`](reference/Field.md#general-field-settings).)
+
 ## Filtering
 
 All filter fields are added as a serialized object passed as the value of the `_filters` query parameter. For instance, the following `filterView()` configuration:

--- a/doc/reference/Field.md
+++ b/doc/reference/Field.md
@@ -53,7 +53,11 @@ Create a new field of the given type. Default type is 'string', so you can omit 
 Define the label of the field. Defaults to the uppercased field name.
 
 * `editable(boolean)`
-Define if the field is editable in the edition form. Usefult to display a field without allowing edition (e.g for creation date).
+Define if the field is editable in the edition form. Useful to display a field without allowing edition (e.g for creation date).
+
+* `sortable(boolean)`
+Define if the field is sortable in the list view (default `true`).
+(See ["Sort Columns and Sort Order"](../API-mapping.md#sort-columns-and-sort-order) for a discussion of how to integrate `ng-admin` sorting with your REST backend.)
 
 * `order(number|null)`
 Define the position of the field in the view.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/marmelab/ng-admin.git"
   },
   "devDependencies": {
-    "admin-config": "^0.11.0",
+    "admin-config": "^0.12.0",
     "angular": "~1.4.8",
     "angular-mocks": "~1.4.8",
     "angular-numeraljs": "^1.1.6",

--- a/src/javascripts/ng-admin/Crud/list/maDatagrid.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagrid.js
@@ -26,10 +26,13 @@ export default function maDatagrid() {
                 <ma-datagrid-multi-selector toggle-select-all="toggleSelectAll()" selection="selection" entries="entries"/>
             </th>
             <th ng-repeat="field in fields() track by $index" ng-class="field.getCssClasses()" class="ng-admin-column-{{ ::field.name() }} ng-admin-type-{{ ::field.type() }}">
-                <a ng-click="datagrid.sortCallback(field)">
+                <a ng-if="field.sortable()" ng-click="datagrid.sortCallback(field)">
                     <span class="glyphicon {{ sortDir() === 'DESC' ? 'glyphicon-chevron-up': 'glyphicon-chevron-down' }}" ng-if="datagrid.isSorting(field)"></span>
                     {{ field.label() | translate }}
                 </a>
+                <span ng-if="!field.sortable()">
+                    {{ field.label() | translate }}
+                </span>
             </th>
             <th ng-if="datagrid.shouldDisplayActions" class="ng-admin-column-actions" translate="ACTIONS"></th>
         </tr>


### PR DESCRIPTION
Fixes https://github.com/marmelab/ng-admin/issues/372

(UPDATE: please ignore the rest of this comment, it refers to an old version of this PR. Jump straight to [the comment starting "OK, I have updated this pull request to include the necessary changes"](#issuecomment-205234237))

As discussed on that thread, this PR is much easier if I don't have to also modify `admin-config`.
However, it does look rather out of place next to all the fields with function getters & setters, so maybe a version which spans the two respositories would be better.

This version works for me though.

(Another benefit of the getter/setter approach is that it allows a "builder" style. This version is awkward to use:

```
articles.listView()
   .fields(
       nga.field('id'),
       function() {
            var headline = nga.field('headline');
            // Headline is an "analyzed" string field, so cannot be sorted in ES
            // https://www.elastic.co/guide/en/elasticsearch/guide/current/multi-fields.html
            headline.disableSort = true;
            return headline;
        }(),
        nga.field('publication_time', 'datetime'),
        nga.field('type')
    ])
```

whereas the getter/setter version would look like

```
articles.listView()
   .fields(
       nga.field('id'),
       nga.field('headline')
            // Headline is an "analyzed" string field, so cannot be sorted in ES
            // https://www.elastic.co/guide/en/elasticsearch/guide/current/multi-fields.html
            .disableSort(true),
        nga.field('publication_time', 'datetime'),
        nga.field('type')
    ])
```

)
