### PR TITLE
Document setting the type for the field

### DIFF
--- a/doc/Custom-types.md
+++ b/doc/Custom-types.md
@@ -171,6 +171,17 @@ myApp.config(['FieldViewConfigurationProvider', function(fvp) {
 }]);
 ```
 
+To use this field view, alter the field class and set its `_type` property:
+```js
+class AmountField extends NumberField {
+    constructor(name) {
+        super(name);
+        this._type = 'amount';
+        ...
+    }
+}
+```
+
 ## Using Custom Directives
 
 Optionally, you can write a custom directive, and use that directive in one of the widget definitions.

--- a/doc/Custom-types.md
+++ b/doc/Custom-types.md
@@ -87,6 +87,7 @@ import NumberField from 'admin-config/lib/Field/NumberField';
 class AmountField extends NumberField {
     constructor(name) {
         super(name);
+        this._type = 'amount';
         this._currency = '$';
     }
     currency(currency) {
@@ -169,17 +170,6 @@ You also need to *register* this new field view type in your application for ng-
 myApp.config(['FieldViewConfigurationProvider', function(fvp) {
     fvp.registerFieldView('amount', require('path/to/AmountFieldView'))
 }]);
-```
-
-To use this field view, alter the field class and set its `_type` property:
-```js
-class AmountField extends NumberField {
-    constructor(name) {
-        super(name);
-        this._type = 'amount';
-        ...
-    }
-}
 ```
 
 ## Using Custom Directives


### PR DESCRIPTION
Without the type, the AmountFieldView is not used,
ng-admin uses the inherited NumberFieldView