### PR TITLE
Fixed reference to 'notification' service

### DIFF
--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -28,7 +28,7 @@ export default class FormController {
 
     validateEntry() {
         if (!this.form.$valid) {
-            this.$translate('INVALID_FORM').then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+            this.$translate('INVALID_FORM').then(text => this.notification.log(text, { addnCls: 'humane-flatty-error' }));
             return false;
         }
 


### PR DESCRIPTION
There was a missing 'this' keyword using the notification service in one of the FormController methods.