### PR TITLE
File field: Fixed Upload progress callback

### DIFF
--- a/src/javascripts/ng-admin/Crud/field/maFileField.js
+++ b/src/javascripts/ng-admin/Crud/field/maFileField.js
@@ -60,10 +60,7 @@ export default function maFileField(Upload) {
                         Upload
                             .upload(uploadParams)
                             .progress(function(evt) {
-                                scope.files[evt.config.file.name] = {
-                                    "name": evt.config.file.name,
-                                    "progress": Math.min(100, parseInt(100.0 * evt.loaded / evt.total))
-                                };
+                                scope.files[evt.config.file.name].progress = Math.min(100, parseInt(100.0 * evt.loaded / evt.total));
                             })
                             .success(function(data, status, headers, config) {
                                 scope.files[config.file.name] = {


### PR DESCRIPTION
On multiple file uploads with a configured `apifilename`, the `progress` event change the name of the previous uploaded files.
The `progress event` must only affect the `progress` property.