### PR TITLE
[RFR] In datagrids, apply label styles to all labels

### DIFF
--- a/src/sass/ng-admin.scss
+++ b/src/sass/ng-admin.scss
@@ -149,7 +149,7 @@ ma-view-actions {
 
     background-color: #fff;
 
-    .label-default {
+    .label {
         margin-right: 5px;
         font-weight: normal;
         font-size: 12px;


### PR DESCRIPTION
Not just the `label-default`

before:
![before](https://sc-cdn.scaleengine.net/i/8bd4a98e921ee42038cfd69ce2427c20.png)

after:
![after](https://sc-cdn.scaleengine.net/i/041686d9dc6b1c10de3173e060269d48.png)