### PR TITLE
Update ui-select version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "style-loader": "^0.12.2",
     "superagent": "^0.18.2",
     "textangular": "1.4.3",
-    "ui-select": "angular-ui/ui-select#271bf6a03078587c5afdb05f61e826573a13d348",
+    "ui-select": "^0.17.1",
     "underscore": "^1.8.3",
     "url-loader": "^0.5.5",
     "webpack": "^1.10.0",


### PR DESCRIPTION
This update fixes "[ui.select:transcluded] Expected 1 .ui-select-match but got '0'. error