### PR TITLE
Fix error messages on failed deletes, updates

### DIFF
--- a/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/BatchDeleteController.js
@@ -30,11 +30,13 @@ export default class BatchDeleteController {
                 $translate('BATCH_DELETE_SUCCESS').then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) | 'ERROR_MESSAGE';
+                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
                 $translate(errorMessage, {
                     status: error && error.status,
                     details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                }).then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                })
+                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -43,11 +43,13 @@ export default class DeleteController {
                 $translate('DELETE_SUCCESS').then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) | 'ERROR_MESSAGE';
+                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
                 $translate(errorMessage, {
                     status: error && error.status,
                     details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                }).then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                })
+                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -71,7 +71,7 @@ export default class FormController {
                     .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) | 'ERROR_MESSAGE';
+                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
                 const customHandlerReturnValue = view.onSubmitError() && this.$injector.invoke(
                     view.onSubmitError(),
                     view,
@@ -82,7 +82,9 @@ export default class FormController {
                 $translate(errorMessage, {
                     status: error && error.status,
                     details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                }).then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                })
+                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 
@@ -114,7 +116,7 @@ export default class FormController {
                     .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) | 'ERROR_MESSAGE';
+                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
                 const customHandlerReturnValue = view.onSubmitError() && this.$injector.invoke(
                     view.onSubmitError(),
                     view,
@@ -125,7 +127,9 @@ export default class FormController {
                 $translate(errorMessage, {
                     status: error && error.status,
                     details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                }).then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                })
+                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 


### PR DESCRIPTION
This is a fix for items 1 & 2 described at https://github.com/marmelab/ng-admin/issues/1129#issuecomment-226500647

It does not fix item 3.

New test results:

```
Given an entity where the REST backend will return 400 "cannot delete due to xyz" for a "DELETE" request
When I view the "edit" page for that entity
And I click the "delete" button
And I click "Yes" to "are you sure?"
Then I should see an error banner including "cannot delete due to xyz"
 # this passes now (and fails before these changes)

Given an entity where the REST backend will return 400 "cannot delete due to xyz" for a "DELETE" request
When I view the "list" page for that entity tytpe
And I select that entity
And I click the "delete" button
And I click "Yes" to "are you sure?"
Then I should see an error banner including "cannot delete due to xyz"
 # this still fails due to item #3
 # I see a success banner
```
