### PR TITLE
[RFR] Fix npm main source

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha6",
   "license": "MIT",
   "private": false,
-  "main": "lib/javascripts/ng-admin.js",
+  "main": "src/javascripts/ng-admin.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/marmelab/ng-admin.git"


### PR DESCRIPTION
Since the folder is renamed, the package.json file have been updated (https://github.com/marmelab/ng-admin/pull/1189/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R14) but not its `main` attribute.