### PR TITLE
Use lodash instead of underscore to avoid conflict with Restangular

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "restangular": "~1.5.2",
     "textangular": "1.4.3",
     "ui-select": "0.18.1",
-    "lodash": ">=1.3.0"
+    "lodash.debounce": "4.0.8"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "restangular": "~1.5.2",
     "textangular": "1.4.3",
     "ui-select": "0.18.1",
-    "underscore": "^1.8.3"
+    "lodash": ">=1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.8",

--- a/src/javascripts/vendors.js
+++ b/src/javascripts/vendors.js
@@ -11,5 +11,3 @@ require('angular-translate');
 require('angular-numeraljs');
 require('angular-ui-bootstrap/dist/ui-bootstrap-tpls');
 require('ng-file-upload');
-
-global._ = require('lodash');

--- a/src/javascripts/vendors.js
+++ b/src/javascripts/vendors.js
@@ -12,4 +12,4 @@ require('angular-numeraljs');
 require('angular-ui-bootstrap/dist/ui-bootstrap-tpls');
 require('ng-file-upload');
 
-global._ = require('underscore');
+global._ = require('lodash');


### PR DESCRIPTION
On latest build I am getting the error _.includes is not a function when navigating into one of my custom pages.

Following several threads on Restangular Git (one of them being mgonto/restangular#1225). I found out that Restangular is now compatible with lodash 4.

ng-admin using underscore is causing incompatibilty since the new webpack dependency version has been merged. Making use of lodash fixes the problems