### PR TITLE
[RFR] Fix infinite scrolling request synchronization

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/ListController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListController.js
@@ -23,6 +23,7 @@ export default class ListController {
         this.setPageCallback = this.setPage.bind(this);
         this.sortField = this.$stateParams.sortField || this.view.getSortFieldName();
         this.sortDir = this.$stateParams.sortDir || this.view.sortDir();
+        this.queryPromises = [];
 
         if ($scope.selectionUpdater) {
             $scope.selection = $scope.selection || [];
@@ -47,7 +48,7 @@ export default class ListController {
         const references = view.getReferences();
         let data;
 
-        this.ReadQueries
+        let queryPromise = this.ReadQueries
             .getAll(view, page, this.search, this.sortField, this.sortDir)
             .then(response => {
                 data = response.data;
@@ -65,6 +66,9 @@ export default class ListController {
                     ).map(entry => dataStore.addEntry(references[name].targetEntity().uniqueId + '_values', entry));
                 }
             })
+        this.queryPromises.push(queryPromise);
+        // make sure all preceding promises complete before loading data into store
+        Promise.all(this.queryPromises)
             .then(() => {
                 view.mapEntries(data)
                     .map(entry => {

--- a/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
@@ -25,7 +25,7 @@ export default function maDatagridInfinitePagination($window, $document) {
                         return;
                     }
                     page++;
-                    if(loadedPages.includes(page)){
+                    if(page in loadedPages){
                         return;
                     }
                     loadedPages.push(page);

--- a/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
@@ -17,13 +17,18 @@ export default function maDatagridInfinitePagination($window, $document) {
             var perPage = parseInt(scope.perPage, 10) || 1,
                 totalItems = parseInt(scope.totalItems, 10),
                 nbPages = Math.ceil(totalItems / perPage) || 1,
-                page = 1;
+                page = 1,
+                loadedPages = [];
             function handler() {
                 if (body.offsetHeight - $window.innerHeight - $window.scrollY < offset) {
                     if (page >= nbPages) {
                         return;
                     }
                     page++;
+                    if(loadedPages.includes(page)){
+                        return;
+                    }
+                    loadedPages.push(page);
                     scope.nextPage()(page);
                 }
             }

--- a/src/javascripts/test/unit/Crud/list/maDatagridInfinitePaginationSpec.js
+++ b/src/javascripts/test/unit/Crud/list/maDatagridInfinitePaginationSpec.js
@@ -50,6 +50,7 @@ describe('directive: ma-datagrid-infinite-pagination', function () {
         $compile = _$compile_;
         scope = _$rootScope_.$new();
         $window = _$window_;
+        $window.innerHeight = 759;
         $document = _$document_;
         initializeBodyHeightMock();
         initializeScope();

--- a/src/javascripts/test/unit/Crud/list/maDatagridInfinitePaginationSpec.js
+++ b/src/javascripts/test/unit/Crud/list/maDatagridInfinitePaginationSpec.js
@@ -1,0 +1,91 @@
+/*global angular,inject,describe,it,jasmine,expect,beforeEach,module*/
+describe('directive: ma-datagrid-infinite-pagination', function () {
+    var directive = require('../../../../ng-admin/Crud/list/maDatagridInfinitePagination'),
+        $compile,
+        scope,
+        $window,
+        $document,
+        element,
+        bodyHeightMock,
+        pageSize = 2000,
+        directiveUsage = '<ma-datagrid-infinite-pagination next-page="nextPage" total-items="{{ totalItems }}" per-page="{{ itemsPerPage }}"></ma-datagrid-infinite-pagination>';
+
+    function initializeBodyHeightMock(){
+        if(!angular.element($document[0].querySelector('#mock')).length){
+            bodyHeightMock = angular.element(`<div id="mock" style="height:${pageSize}px"></div>`)[0];
+            angular.element($document[0].body).append(bodyHeightMock);
+        }else{
+            simulateLoadOnBodyHeight(1);
+        }
+    }
+
+    function simulateLoadOnBodyHeight(page){
+        angular.element($document[0].querySelector('#mock')).css('height',(pageSize*page) + 'px');
+    }
+
+    function simulateScrollToPage(page){
+        $window.scrollY = pageSize * (page-1) + 1500;
+        angular.element($window).triggerHandler('scroll');
+    }
+
+    function initializeScope(){
+        scope.nextPage = jasmine.createSpy('nextPage').and.callFake(function(page) {
+            simulateLoadOnBodyHeight(page);
+        });
+        scope.totalItems = 100;
+        scope.itemsPerPage = 10;
+    }
+
+    function initializeElement(){
+        element = $compile(directiveUsage)(scope);
+        scope.$digest();
+    }
+
+    angular.module('testapp_DatagridInfinitePagination', [])
+        .directive('maDatagridInfinitePagination', directive);
+
+    beforeEach(angular.mock.module('testapp_DatagridInfinitePagination'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$window_, _$document_) {
+        $compile = _$compile_;
+        scope = _$rootScope_.$new();
+        $window = _$window_;
+        $document = _$document_;
+        initializeBodyHeightMock();
+        initializeScope();
+        initializeElement();
+    }));
+
+    it('should trigger next-page when scrolling', function () {
+        simulateScrollToPage(2);
+        expect(scope.nextPage).toHaveBeenCalled();
+    });
+
+    it('should trigger next-page twice when scrolling twice', function(){
+        simulateScrollToPage(2);
+        simulateScrollToPage(3);
+        expect(scope.nextPage.calls.count()).toEqual(2);
+    });
+
+    it('should trigger next-page with right page number', function(){
+        simulateScrollToPage(2);
+        simulateScrollToPage(3);
+        expect(scope.nextPage.calls.argsFor(0)).toEqual([2]);
+        expect(scope.nextPage.calls.argsFor(1)).toEqual([3]);
+    });
+
+    it('should not trigger next-page if not scrolling', function () {
+        expect(scope.nextPage).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger next-page when scrolling up', function(){
+        simulateScrollToPage(2);
+        simulateScrollToPage(3);
+        simulateScrollToPage(2);
+        expect(scope.nextPage.calls.count()).toEqual(2);
+    });
+
+    afterEach(function(){
+        scope.$destroy();
+    });
+});


### PR DESCRIPTION
Fix infinite scrolling list view :

- [x] Requests gets fired again when scrolling upwards adding duplicated into the dataset
- [x] If multiple requests gets fired at the same time, they might not be loaded into the dataset on the right order and thus mess with sorts