### PR TITLE
Use lodash instead of underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "rangy": "^1.3.0",
     "restangular": "~1.5.2",
     "textangular": "1.4.3",
-    "ui-select": "0.18.1",
-    "underscore": "^1.8.3"
+    "ui-select": "0.18.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.8",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "karma-ng-scenario": "~0.1.0",
     "karma-phantomjs-launcher": "~1.0.0",
     "karma-webpack": "~1.7.0",
+    "lodash": "^4.17.2",
+    "lodash.debounce": "4.0.8",
     "mocha": "^2.1.0",
     "ng-annotate-loader": "0.0.2",
     "ngtemplate-loader": "^1.3.0",

--- a/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
@@ -1,4 +1,4 @@
-/* globals _ */
+const debounce = require('lodash.debounce');
 
 export default class ListLayoutController {
     constructor($scope, $stateParams, $state, $location, $timeout, view, dataStore) {
@@ -34,7 +34,7 @@ export default class ListLayoutController {
         // apply filters when filter values change
         $scope.$watch(
             () => this.search,
-            _.debounce((newValues, oldValues) => {
+            debounce((newValues, oldValues) => {
                 if (newValues != oldValues) {
                     this.updateFilters();
                 }

--- a/src/javascripts/vendors.js
+++ b/src/javascripts/vendors.js
@@ -12,4 +12,4 @@ require('angular-numeraljs');
 require('angular-ui-bootstrap/dist/ui-bootstrap-tpls');
 require('ng-file-upload');
 
-global._ = require('underscore');
+global._ = require('lodash');


### PR DESCRIPTION
As discussed with @fzaninotto, reopening this PR. I have left the original implementation with a global delcared in the vendor.js since this is the solution I tested.

On latest build I am getting the error _.includes is not a function when navigating into one of my custom pages.
Following several threads on Restangular Git (one of them being mgonto/restangular#1225). I found out that Restangular is now compatible with lodash 4.

ng-admin using underscore is causing incompatibilty since the new webpack dependency version has been merged. Making use of lodash fixes the problems