### PR TITLE
[RFR] Fix filter which was overwriting url after a change

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
+++ b/src/javascripts/ng-admin/Crud/list/ListLayoutController.js
@@ -27,7 +27,6 @@ export default class ListLayoutController {
                 if ($location.path() !== this.path) {
                     return; // already transitioned to another page
                 }
-                this.search = ListLayoutController.getCurrentSearchParam($location, this.filters);
                 this.enabledFilters = this.getEnabledFilters();
             }
         );

--- a/src/javascripts/test/unit/Crud/field/maEmbeddedListFieldSpec.js
+++ b/src/javascripts/test/unit/Crud/field/maEmbeddedListFieldSpec.js
@@ -45,11 +45,11 @@ describe('directive: ma-embedded-list-field', function () {
         expect(element.find('a').eq(1).text().trim()).toBe('REMOVE');
         expect(element.find('input').eq(2).scope().value).toBe(2);
         expect(element.find('input').eq(3).scope().value).toBe('bar');
-        expect(element.find('a').eq(2).text().trim()).toBe('ADD_NEW');
+        expect(element.find('a').eq(2).text().trim()).toBe('ADD_NEW dummy');
     });
 
     describe('Add Button', () => {
-        fit('should display lower-cased label', () => {
+        it('should display lower-cased label', () => {
             scope.field = new EmbeddedListField('dummy_field')
                 .label('Awesome Entity');
 


### PR DESCRIPTION
Because of this, depending of how fast user was typing its search filter, some of its characters were overriden with the previous search.