### PR TITLE
[RFR] Check for fit, fdescribe or .only in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ build:
 	cp -Rf build examples/blog/
 	@echo "Files build/ng-admin.min.css and build/ng-admin.min.js updated (with minification)"
 
-test: test-unit test-e2e
+test: check-only-in-tests test-unit test-e2e
+
+check-only-in-tests:
+	bash ./scripts/check-only-in-tests.sh
 
 test-unit:
 	./node_modules/.bin/karma start src/javascripts/test/karma.conf.js --single-run

--- a/scripts/check-only-in-tests.sh
+++ b/scripts/check-only-in-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+SRC=$(git rev-parse --show-toplevel)
+EXCLUDE="--exclude-dir 'node_modules' --exclude-dir '.git'"
+
+#==========================================================
+# Check if I forgot to remove 'only' keyword from tests.
+# To make sure that before commit run all tests
+only_command="grep -c -h -r $EXCLUDE -E \"(describe|it)\.only\" $SRC | awk -F ':' '{x +=\$0}; END {print x}'"
+fonly_command="grep -c -h -r $EXCLUDE -E \"f(it|describe)\(\" $SRC | awk -F ':' '{x +=\$0}; END {print x}'"
+only=`eval $only_command`
+fonly=`eval $fonly_command`
+
+if (( $((only + fonly)) > 0 ))
+then
+  echo 'Remove ONLY from tests.'
+  # Output list of found only entries
+  eval "grep -r -n $EXCLUDE -E \"(describe|it)\.only\" $SRC"
+  eval "grep -r -n $EXCLUDE -E \"f(it|describe)\(\" $SRC"
+  exit 1
+fi


### PR DESCRIPTION
In order to avoid `fit`, `fdescribe` or `.only` on master.