### PR TITLE
[RFR] Remove selenium installation from post install hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 install:
 	npm install
+	node _postinstall.js
 
 run: examples/blog/build
 	cp node_modules/fakerest/dist/FakeRest.min.js examples/blog/build/fakerest.js

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "node": ">=4.2.0"
   },
   "scripts": {
-    "test": "make test",
-    "postinstall": "node _postinstall.js"
+    "test": "make test"
   }
 }


### PR DESCRIPTION
@Phocea We are forced to do it this way since the `_postinstall.js` file is excluded from the NPM build.