### PR TITLE
[RFR] Handle CRUD form error through http error service

### DIFF
--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -181,6 +181,8 @@ entity.errorMessage(function (response) {
     return 'Global error: ' + response.status + '(' + response.data + ')';
 });
 ```
+If you do not customize the error message using that method, it will be globally handled by the [Http Error Service](../src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js).
+
 ## Customizing HTTP Error Messages
 
 If you want to override, patch or extend the way HTTP errors are handled by the ng-admin [Http Error Service](../src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js) then you may use an [Angular decorator](https://docs.angularjs.org/guide/decorators), as per the below example:

--- a/doc/Theming.md
+++ b/doc/Theming.md
@@ -215,3 +215,4 @@ Bind the decorator to your application:
 ```js
 myApp.decorator('HttpErrorService',require('HttpErrorDecorator'));
 ```
+The decorator can also be used to globally customize CRUD error messages

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -1,5 +1,5 @@
 export default class DeleteController {
-    constructor($scope, $window, $state, $q, $translate, WriteQueries, Configuration, progression, notification, params, view, entry) {
+    constructor($scope, $window, $state, $q, $translate, WriteQueries, Configuration, progression, notification, params, view, entry, HttpErrorService) {
         this.$scope = $scope;
         this.$window = $window;
         this.$state = $state;
@@ -17,6 +17,7 @@ export default class DeleteController {
         this.notification = notification;
         this.$scope.entry = entry;
         this.$scope.view = view;
+        this.HttpErrorService = HttpErrorService;
 
         $scope.$on('$destroy', this.destroy.bind(this));
 
@@ -45,14 +46,14 @@ export default class DeleteController {
             .then(() => $translate('DELETE_SUCCESS'))
             .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                const errorMessage = this.HttpErrorService.handleError(this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE');
                 progression.done();
-                $translate(errorMessage, {
-                    status: error && error.status,
-                    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                })
-                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
-                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                //$translate(errorMessage, {
+                //    status: error && error.status,
+                //    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
+                //})
+                //    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                //   .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 
@@ -70,7 +71,8 @@ export default class DeleteController {
         this.entity = undefined;
         this.progression = undefined;
         this.notification = undefined;
+        this.HttpErrorService = undefined;
     }
 }
 
-DeleteController.$inject = ['$scope', '$window', '$state', '$q', '$translate', 'WriteQueries', 'NgAdminConfiguration', 'progression', 'notification', 'params', 'view', 'entry'];
+DeleteController.$inject = ['$scope', '$window', '$state', '$q', '$translate', 'WriteQueries', 'NgAdminConfiguration', 'progression', 'notification', 'params', 'view', 'entry', 'HttpErrorService'];

--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -46,14 +46,12 @@ export default class DeleteController {
             .then(() => $translate('DELETE_SUCCESS'))
             .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
             .catch(error => {
-                const errorMessage = this.HttpErrorService.handleError(this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE');
+                // this is kept for backward compatibility with the entity.errorMessage() method 
+                const msg = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                error.data.message = msg;
+                
+                this.HttpErrorService.handleError(error);
                 progression.done();
-                //$translate(errorMessage, {
-                //    status: error && error.status,
-                //    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                //})
-                //    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
-                //   .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -72,7 +72,11 @@ export default class FormController {
             .then(() => $translate('CREATION_SUCCESS'))
             .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                // this is kept for backward compatibility with the entity.errorMessage() method 
+                const msg = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                error.data.message = msg;
+                
+                const errorMessage = this.HttpErrorService.handleError(error);
                 const customHandlerReturnValue = view.onSubmitError() && this.$injector.invoke(
                     view.onSubmitError(),
                     view,
@@ -80,12 +84,6 @@ export default class FormController {
                 );
                 if (customHandlerReturnValue === false) return;
                 progression.done();
-                $translate(errorMessage, {
-                    status: error && error.status,
-                    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                })
-                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
-                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 
@@ -117,7 +115,11 @@ export default class FormController {
                     .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.HttpErrorService.handleError(this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE');
+                // this is kept for backward compatibility with the entity.errorMessage() method 
+                const msg = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                error.data.message = msg;
+                
+                const errorMessage = this.HttpErrorService.handleError(error);
                 const customHandlerReturnValue = view.onSubmitError() && this.$injector.invoke(
                     view.onSubmitError(),
                     view,
@@ -125,12 +127,6 @@ export default class FormController {
                 );
                 if (customHandlerReturnValue === false) return;
                 progression.done();
-                //$translate(errorMessage, {
-                //    status: error && error.status,
-                //    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                //})
-                //    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
-                //    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 
@@ -144,7 +140,7 @@ export default class FormController {
         this.dataStore = undefined;
         this.view = undefined;
         this.entity = undefined;
-        this.HttpErrorService = undefined;
+        this.HttpErrorService = HttpErrorService;
     }
 }
 

--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -1,5 +1,5 @@
 export default class FormController {
-    constructor($scope, $state, $injector, $translate, previousState, WriteQueries, Configuration, progression, notification, view, dataStore) {
+    constructor($scope, $state, $injector, $translate, previousState, WriteQueries, Configuration, progression, notification, view, dataStore, HttpErrorService) {
         this.$scope = $scope;
         this.$state = $state;
         this.$injector = $injector;
@@ -19,6 +19,7 @@ export default class FormController {
         this.$scope.entry = dataStore.getFirstEntry(this.entity.uniqueId);
         this.$scope.view = view;
         this.$scope.entity = this.entity;
+        this.HttpErrorService = HttpErrorService;
 
         // in case of entity identifier being modified
         this.originEntityId = this.$scope.entry.values[this.entity.identifier().name()];
@@ -116,7 +117,7 @@ export default class FormController {
                     .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }));
             })
             .catch(error => {
-                const errorMessage = this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE';
+                const errorMessage = this.HttpErrorService.handleError(this.config.getErrorMessageFor(this.view, error) || 'ERROR_MESSAGE');
                 const customHandlerReturnValue = view.onSubmitError() && this.$injector.invoke(
                     view.onSubmitError(),
                     view,
@@ -124,12 +125,12 @@ export default class FormController {
                 );
                 if (customHandlerReturnValue === false) return;
                 progression.done();
-                $translate(errorMessage, {
-                    status: error && error.status,
-                    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
-                })
-                    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
-                    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
+                //$translate(errorMessage, {
+                //    status: error && error.status,
+                //    details: error && error.data && typeof error.data === 'object' ? JSON.stringify(error.data) : {}
+                //})
+                //    .catch(angular.identity) // See https://github.com/angular-translate/angular-translate/issues/1516
+                //    .then(text => notification.log(text, { addnCls: 'humane-flatty-error' }));
             });
     }
 
@@ -143,7 +144,8 @@ export default class FormController {
         this.dataStore = undefined;
         this.view = undefined;
         this.entity = undefined;
+        this.HttpErrorService = undefined;
     }
 }
 
-FormController.$inject = ['$scope', '$state', '$injector', '$translate', 'previousState', 'WriteQueries', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'dataStore'];
+FormController.$inject = ['$scope', '$state', '$injector', '$translate', 'previousState', 'WriteQueries', 'NgAdminConfiguration', 'progression', 'notification', 'view', 'dataStore', 'HttpErrorService'];

--- a/src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js
+++ b/src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js
@@ -2,13 +2,13 @@ const HttpErrorService = ($state, $translate, notification) => ({
     handleError: function(error, event, toState, toParams, fromState, fromParams) {
         switch (error.status) {
             case 404:
-               this.handle404Error(event, error);
+               this.handle404Error(event);
                break;
             case 403:
                this.handle403Error(error);
                break;
             default:
-               this.handleDefaultError(error);
+               this.handleDefaultError(error, event);
                break;
         }
     },
@@ -24,7 +24,11 @@ const HttpErrorService = ($state, $translate, notification) => ({
     },
 
     handleDefaultError: function(error) {
-        $translate('STATE_CHANGE_ERROR', { message: error.data.message }).then(this.displayError);
+        if (event) {
+            $translate('STATE_CHANGE_ERROR', { message: error.data.message }).then(this.displayError);
+        } else {
+            $translate('GLOBAL_ERROR', { message: error.data.message }).then(this.displayError);
+        }
          throw error;
      },
 

--- a/src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js
+++ b/src/javascripts/ng-admin/Main/component/provider/HttpErrorService.js
@@ -1,5 +1,5 @@
 const HttpErrorService = ($state, $translate, notification) => ({
-    handleError: function(event, toState, toParams, fromState, fromParams, error) {
+    handleError: function(error, event, toState, toParams, fromState, fromParams) {
         switch (error.status) {
             case 404:
                this.handle404Error(event, error);

--- a/src/javascripts/ng-admin/Main/config/translate.js
+++ b/src/javascripts/ng-admin/Main/config/translate.js
@@ -39,6 +39,7 @@ export default function translate($translateProvider) {
       'DETAIL': 'Detail',
       'STATE_CHANGE_ERROR': 'State change error: {{ message }}',
       'STATE_FORBIDDEN_ERROR': 'A server 403 error occured: {{ message }}',
+      'GLOBAL_ERROR': 'Global error: {{ message }}',
       'NOT_FOUND': 'Not Found',
       'NOT_FOUND_DETAILS': 'The page you are looking for cannot be found. Take a break before trying again.',
     });

--- a/src/javascripts/ng-admin/Main/run/HttpErrorHandler.js
+++ b/src/javascripts/ng-admin/Main/run/HttpErrorHandler.js
@@ -1,6 +1,6 @@
 export default function HttpErrorHandler($rootScope, HttpErrorService) {
     $rootScope.$on("$stateChangeError", (event, toState, toParams, fromState, fromParams, error) => {
-    	HttpErrorService.handleError(event, toState, toParams, fromState, fromParams, error);
+    	HttpErrorService.handleError(error, event, toState, toParams, fromState, fromParams);
     });
 }
 

--- a/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
+++ b/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
@@ -33,7 +33,7 @@ describe('Http Error Service', () => {
         };
 
         const error = { status: 404 };
-        HttpErrorService.handleError(event, '', '', '', '', error);
+        HttpErrorService.handleError(error, event, '', '', '', '');
 
         expect(event.preventDefault).toHaveBeenCalled();
         expect($state.go).toHaveBeenCalledWith('ma-404');
@@ -48,7 +48,7 @@ describe('Http Error Service', () => {
         };
 
         try {
-            HttpErrorService.handleError('', '', '', '', '', error);
+            HttpErrorService.handleError(error'', '', '', '', '');
             expect(true).toBe(false);
         } catch (e) {
             // should throw an exception in case of 403
@@ -67,7 +67,7 @@ describe('Http Error Service', () => {
         };
 
         try {
-            HttpErrorService.handleError('', '', '', '', '', error);
+            HttpErrorService.handleError(error, '', '', '', '', '');
             expect(true).toBe(false);
         } catch (e) {
             // should throw an exception in case of 500

--- a/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
+++ b/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
@@ -48,7 +48,7 @@ describe('Http Error Service', () => {
         };
 
         try {
-            HttpErrorService.handleError(error'', '', '', '', '');
+            HttpErrorService.handleError(error, '', '', '', '', '');
             expect(true).toBe(false);
         } catch (e) {
             // should throw an exception in case of 403

--- a/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
+++ b/src/javascripts/test/unit/Main/component/provider/HttpErrorServiceTest.spec.js
@@ -73,7 +73,7 @@ describe('Http Error Service', () => {
             // should throw an exception in case of 500
         }
 
-        expect($translate).toHaveBeenCalledWith('STATE_CHANGE_ERROR', { message: 'Unknown error' });
+        expect($translate).toHaveBeenCalledWith('GLOBAL_ERROR', { message: 'Unknown error' });
         expect(notification.log).toHaveBeenCalledWith('translated', { addnCls: 'humane-flatty-error' });
     });
 });


### PR DESCRIPTION
This PR is aim to make use of the new HttpErrorService to display CRUD form http error responses.
For backward compatibility, the code still pick up customization done via [entity.errorMessage method](https://github.com/marmelab/ng-admin/blob/Handle-Crud-Form-Error-Through-HttpErrorService/doc/Theming.md#customizing-error-messages). However this step is now redudant since it can be done inside an decorator

## TODO
- [x] More specific unit tests?
- [x] Discuss with the team if this is the correct implementation.
- [x] Update doc
