### PR TITLE
Makefile: Fix generating source-map with webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ transpile:
 
 build:
 	make transpile
-	NODE_ENV=production ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe --progress --devtool --source-map
+	NODE_ENV=production ./node_modules/webpack/bin/webpack.js -p --optimize-minimize --optimize-occurence-order --optimize-dedupe --progress --devtool source-map
 	cp -Rf build examples/blog/
 	@echo "Files build/ng-admin.min.css and build/ng-admin.min.js updated (with minification)"
 


### PR DESCRIPTION
ATM there are no sourcemaps available, what is quite a pain to debug. It seems as if they were intended to exist in the first place.

The command in the Makefile is slightly different to really get sourcemaps for the `ng-admin.min.js` and `ng-admin.min.css` files.