### PR TITLE
maDateField timezone adjustment. Fixes #1271 #1305

### DIFF
--- a/src/javascripts/ng-admin/Crud/field/maDateField.js
+++ b/src/javascripts/ng-admin/Crud/field/maDateField.js
@@ -29,7 +29,7 @@ export default function maDateField() {
                     return;
                 }
 
-                scope.rawValue = scope.value instanceof Date ? scope.value : new Date(scope.value);
+                scope.rawValue = scope.value instanceof Date ? scope.value : new Date(new Date(scope.value).getTime() + (new Date().getTimezoneOffset() * 60000));
             });
 
             scope.format = field.format();


### PR DESCRIPTION
There's an infinite loop $watching value and rawValue, because the `Date` object adjust the `yyyy-mm-dd` value to the user's timezone, then modifying the original value +- the timezone. This patch adjust the timezone, so the rawValue is kept as the original value.