### PR TITLE
[RFR] Use http error service handlers inside view events

### DIFF
--- a/src/javascripts/ng-admin/Crud/delete/DeleteController.js
+++ b/src/javascripts/ng-admin/Crud/delete/DeleteController.js
@@ -28,42 +28,48 @@ export default class DeleteController {
     }
 
     deleteOne($event) {
-        const entityName = this.entity.name();
-        const { $translate, notification, progression } = this;
-        progression.start();
+        return new Promise((resolve, reject) => {
+            const entityName = this.entity.name();
+            const { $translate, notification, progression } = this;
+            progression.start();
 
-        return this.previousStateParametersDeferred.promise
-            .then((previousStateParameters) => {
-                const fromState = 'delete';
-                const fromParams = previousStateParameters;
-                let toState;
-                let toParams;
+            this.previousStateParametersDeferred.promise
+                .then((previousStateParameters) => {
+                    const fromState = 'delete';
+                    const fromParams = previousStateParameters;
+                    let toState;
+                    let toParams;
 
-                // if previous page was related to deleted entity,
-                // redirect to list
-                if (fromParams.entity === entityName &&
-                    fromParams.id === this.entityId) {
-                        toState = this.$state.get('list');
-                        toParams = {
-                            entity: entityName,
-                            ...this.$state.params,
-                        };
-                }
+                    // if previous page was related to deleted entity,
+                    // redirect to list
+                    if (fromParams.entity === entityName &&
+                        fromParams.id === this.entityId) {
+                            toState = this.$state.get('list');
+                            toParams = {
+                                entity: entityName,
+                                ...this.$state.params,
+                            };
+                    }
 
-                return this.WriteQueries.deleteOne(this.view, this.entityId)
-                    .then(() => {
-                        if(toState){
-                            return this.$state.go(toState, toParams);
-                        }
-                        return this.back();
-                    })
-                    .then(() => $translate('DELETE_SUCCESS'))
-                    .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
-                    .catch(error => {
-                        progression.done();
-                        this.HttpErrorService.handleError($event, toState, toParams, fromState, fromParams, error);
-                    });
-            });
+                    return this.WriteQueries.deleteOne(this.view, this.entityId)
+                        .then(() => {
+                            if(toState){
+                                return this.$state.go(toState, toParams);
+                            }
+                            return this.back();
+                        })
+                        .then(() => $translate('DELETE_SUCCESS'))
+                        .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
+                        .then(() => {
+                            resolve();
+                        })
+                        .catch(error => {
+                            progression.done();
+                            this.HttpErrorService.handleError($event, toState, toParams, fromState, fromParams, error);
+                            reject();
+                        });
+                });
+        });
     }
 
     back() {

--- a/src/javascripts/ng-admin/Crud/delete/batchDelete.html
+++ b/src/javascripts/ng-admin/Crud/delete/batchDelete.html
@@ -14,7 +14,7 @@
 <div class="row">
     <div class="col-lg-12">
         <p translate="ARE_YOU_SURE"></p>
-        <button class="btn btn-danger" ng-click="batchDeleteController.batchDelete()" translate="YES"></button>
+        <button class="btn btn-danger" ng-click="batchDeleteController.batchDelete($event)" translate="YES"></button>
         <button class="btn btn-default" ng-click="batchDeleteController.back()" translate="NO"></button>
     </div>
 </div>

--- a/src/javascripts/ng-admin/Crud/delete/delete.html
+++ b/src/javascripts/ng-admin/Crud/delete/delete.html
@@ -15,7 +15,7 @@
 <div class="row" id="delete-view">
     <div class="col-lg-12">
         <p translate="ARE_YOU_SURE"></p>
-        <button class="btn btn-danger" ng-click="deleteController.deleteOne()" translate="YES"></button>
+        <button class="btn btn-danger" ng-click="deleteController.deleteOne($event)" translate="YES"></button>
         <button class="btn btn-default" ng-click="deleteController.back()" translate="NO"></button>
     </div>
 </div>

--- a/src/javascripts/test/unit/Crud/delete/BatchDeleteControllerSpec.js
+++ b/src/javascripts/test/unit/Crud/delete/BatchDeleteControllerSpec.js
@@ -1,0 +1,74 @@
+describe('BatchDeleteController', function () {
+    'use strict';
+
+    const BatchDeleteController = require('../../../../ng-admin/Crud/delete/BatchDeleteController'),
+        Entity = require('admin-config/lib/Entity/Entity'),
+        humane = require('humane-js');
+
+    let $scope;
+    beforeEach(inject(function ($controller, $rootScope) {
+        $scope = $rootScope.$new();
+    }));
+
+    describe('batchDelete', function() {
+        const $translate = text => text;
+        const $state = {
+            current:{
+                name: 'list',
+                params: {},
+            },
+            go: jasmine.createSpy('$state.go'),
+            get: jasmine.createSpy('$state.get').and.callFake(state => state),
+            params: {}
+        };
+        const progression = {
+            start: () => true,
+            done: () => true,
+        };
+        const notification = humane;
+        const params = {
+            id: 3,
+            entity: new Entity('post')
+        };
+        const HttpErrorService = {
+            handleError: jasmine.createSpy('HttpErrorService.handleError')
+        };
+        let writeQueries;
+        describe('on error', function() {
+            writeQueries = {
+                batchDelete: jasmine.createSpy('writeQueries.deleteOne')
+                    .and.callFake(() => Promise.reject("Here's a bad bad bad error"))
+            };
+
+            it('should call HttpErrorService handler', (done) => {
+                // assume we are on post #3 deletion page
+                const entity = new Entity('post');
+                const deletedId = 3;
+                const view = {
+                    title: () => 'Deleting a post',
+                    description: () => 'Remove a post',
+                    actions: () => [],
+                    getEntity: () => entity,
+                    fields: () => [],
+                };
+
+                let batchDeleteController = new BatchDeleteController($scope, $state, $translate, writeQueries, progression, notification, view, HttpErrorService);
+
+                batchDeleteController.batchDelete(view, 3)
+                    .then(() => {
+                        assert.fail();
+                        done();
+                    })
+                    .catch(() => {
+                        expect(HttpErrorService.handleError.calls.argsFor(0)[5]).toBe("Here's a bad bad bad error")
+                        done();
+                    });
+
+                const fromStateParams = { entity: 'post', id: 3 };
+                $scope.$emit('$stateChangeSuccess', {}, {}, {}, fromStateParams);
+
+                $scope.$digest();
+            });
+        });
+    });
+});

--- a/src/javascripts/test/unit/Crud/delete/DeleteControllerSpec.js
+++ b/src/javascripts/test/unit/Crud/delete/DeleteControllerSpec.js
@@ -19,7 +19,7 @@ describe('DeleteController', function () {
         });
         var $state = {
             go: jasmine.createSpy('$state.go'),
-            get: jasmine.createSpy('$state.get'),
+            get: jasmine.createSpy('$state.get').and.callFake(state => state),
             params: {}
         };
         var writeQueries = {

--- a/src/javascripts/test/unit/Crud/delete/DeleteControllerSpec.js
+++ b/src/javascripts/test/unit/Crud/delete/DeleteControllerSpec.js
@@ -41,6 +41,9 @@ describe('DeleteController', function () {
             getEntity: () => new Entity('post')
         };
         var entry = {};
+        const HttpErrorService = {
+            handleError: jasmine.createSpy('HttpErrorService.handleError')
+        };
         describe('on success', function() {
             it('should delete given entity', function(done) {
                 // assume we are on post #3 deletion page
@@ -56,7 +59,7 @@ describe('DeleteController', function () {
                 let deleteController = new DeleteController($scope, $window, $state, $q, $translate, writeQueries, Configuration, progression, notification, {
                     id: deletedId,
                     entity: 'post'
-                }, view, entry);
+                }, view, entry, HttpErrorService);
 
                 deleteController.deleteOne(view, 3).then(function() {
                     expect(writeQueries.deleteOne).toHaveBeenCalled();
@@ -83,7 +86,7 @@ describe('DeleteController', function () {
                 let deleteController = new DeleteController($scope, $window, $state, $q, $translate, writeQueries, Configuration, progression, notification, {
                     id: deletedId,
                     entity: 'post'
-                }, view, entry);
+                }, view, entry, HttpErrorService);
 
                 deleteController.deleteOne(view, 3).then(function() {
                     expect($state.get.calls.argsFor(0)[0]).toBe('list');
@@ -114,7 +117,7 @@ describe('DeleteController', function () {
                 let deleteController = new DeleteController($scope, $window, $state, $q, $translate, writeQueries, Configuration, progression, notification, {
                     id: commentId,
                     entity: 'comment'
-                }, view, entry);
+                }, view, entry, HttpErrorService);
 
                 deleteController.deleteOne(view, 3).then(function() {
                     expect($window.history.back).toHaveBeenCalled();
@@ -122,6 +125,43 @@ describe('DeleteController', function () {
                 }, done);
 
                 // assume we come from post #3 page
+                const fromStateParams = { entity: 'post', id: 3 };
+                $scope.$emit('$stateChangeSuccess', {}, {}, {}, fromStateParams);
+
+                $scope.$digest();
+            });
+        });
+        describe('on error', function() {
+            writeQueries = {
+                deleteOne: jasmine.createSpy('writeQueries.deleteOne')
+                    .and.callFake(() => Promise.reject("Here's a bad bad bad error"))
+            };
+            it('should call HttpErrorService handler', (done) => {
+                // assume we are on post #3 deletion page
+                const entity = new Entity('post');
+                const deletedId = 3;
+                const view = {
+                    title: () => 'Deleting a post',
+                    description: () => 'Remove a post',
+                    actions: () => [],
+                    getEntity: () => entity
+                };
+
+                let deleteController = new DeleteController($scope, $window, $state, $q, $translate, writeQueries, Configuration, progression, notification, {
+                    id: deletedId,
+                    entity: 'post'
+                }, view, entry, HttpErrorService);
+
+                deleteController.deleteOne(view, 3)
+                    .then(() => {
+                        assert.fail();
+                        done();
+                    })
+                    .catch(() => {
+                        expect(HttpErrorService.handleError.calls.argsFor(0)[5]).toBe("Here's a bad bad bad error")
+                        done();
+                    });
+
                 const fromStateParams = { entity: 'post', id: 3 };
                 $scope.$emit('$stateChangeSuccess', {}, {}, {}, fromStateParams);
 

--- a/src/javascripts/test/unit/Crud/form/FormControllerSpec.js
+++ b/src/javascripts/test/unit/Crud/form/FormControllerSpec.js
@@ -1,0 +1,155 @@
+describe('FormController', function () {
+    'use strict';
+
+    var FormController = require('../../../../ng-admin/Crud/form/FormController'),
+        Field = require('admin-config/lib/Field/Field'),
+        Entity = require('admin-config/lib/Entity/Entity'),
+        humane = require('humane-js');
+
+    let $scope, $injector;
+    beforeEach(inject(function ($controller, $rootScope, _$injector_) {
+        $scope = $rootScope.$new();
+        $injector = _$injector_;
+    }));
+
+    const entity = new Entity('post')
+        .identifier(new Field('id'));
+    const $translate = text => text;
+    const Configuration = () => ({
+        getErrorMessageFor: () => '',
+    });
+    const $state = {
+        go: jasmine.createSpy('$state.go'),
+        get: jasmine.createSpy('$state.get').and.callFake(state => state),
+        params: {},
+        current:{
+            name: 'list',
+            params: {},
+        }
+    };
+    let writeQueries = {
+        deleteOne: jasmine.createSpy('writeQueries.deleteOne').and.callFake(() => $q.when())
+    };
+    const progression = {
+        start: () => true,
+        done: () => true,
+    };
+    const notification = humane;
+    const params = {
+        id: 3,
+        entity,
+    };
+    const view = {
+        title: () => 'My view',
+        description: () => 'Description',
+        actions: () => [],
+        getEntity: () => entity,
+        fields: () => [],
+        validate: () => true,
+        onSubmitError: () => () => true,
+    };
+    let entry = {
+        transformToRest: () => {},
+    };
+    const HttpErrorService = {
+        handleError: jasmine.createSpy('HttpErrorService.handleError')
+    };
+
+    const previousState = {};
+
+    const dataStore = {
+        getFirstEntry: jasmine.createSpy('dataStore.getFirstEntry')
+            .and.callFake(() => entry),
+    };
+
+    const $event = {
+        preventDefault: () => {},
+    }
+
+    describe('submitCreation', function() {
+        describe('on error', function() {
+            beforeEach(() => {
+                entry = {
+                    ...entry,
+                    values: {
+                        id: 3,
+                    }
+                };
+                writeQueries = {
+                    createOne: jasmine.createSpy('writeQueries.createOne')
+                        .and.callFake(() => Promise.reject("Here's a bad bad bad error"))
+                };
+            });
+
+            it('should call HttpErrorService handler', (done) => {
+                // assume we are on post #3 deletion page
+                const deletedId = 3;
+
+                let formController = new FormController($scope, $state, $injector, $translate, previousState, writeQueries, Configuration, progression, notification, view, dataStore, HttpErrorService);
+
+                formController.form = {
+                    $valid: true,
+                };
+
+                formController.submitCreation($event)
+                    .then(() => {
+                        assert.fail();
+                        done();
+                    })
+                    .catch((error) => {
+                        expect(HttpErrorService.handleError.calls.argsFor(0)[5]).toBe("Here's a bad bad bad error")
+                        done();
+                    });
+
+                const fromStateParams = { entity: 'post', id: 3 };
+                $scope.$emit('$stateChangeSuccess', {}, {}, {}, fromStateParams);
+
+                $scope.$digest();
+            });
+        });
+    });
+
+    describe('submitEdition', function() {
+        describe('on error', function() {
+
+            beforeEach(() => {
+                entry = {
+                    ...entry,
+                    values: {
+                        id: 3,
+                    }
+                };
+                writeQueries = {
+                    updateOne: jasmine.createSpy('writeQueries.updateOne')
+                        .and.callFake(() => Promise.reject("Here's a bad bad bad error"))
+                };
+            });
+
+            it('should call HttpErrorService handler', (done) => {
+                // assume we are on post #3 deletion page
+                const deletedId = 3;
+
+                let formController = new FormController($scope, $state, $injector, $translate, previousState, writeQueries, Configuration, progression, notification, view, dataStore, HttpErrorService);
+
+                formController.form = {
+                    $valid: true,
+                };
+
+                formController.submitEdition($event)
+                    .then(() => {
+                        assert.fail();
+                        done();
+                    })
+                    .catch((error) => {
+                        expect(HttpErrorService.handleError.calls.argsFor(0)[5]).toBe("Here's a bad bad bad error")
+                        done();
+                    });
+
+                const fromStateParams = { entity: 'post', id: 3 };
+                $scope.$emit('$stateChangeSuccess', {}, {}, {}, fromStateParams);
+
+                $scope.$digest();
+            });
+        });
+    });
+});


### PR DESCRIPTION
The `HttpErrorService` decorator wasn't working on view like on "Submit changes".

It should now work.

Still untested, need some more work.