### PR TITLE
Fix Child Menu Highlight

### DIFF
--- a/src/javascripts/ng-admin/Main/view/menuBar.html
+++ b/src/javascripts/ng-admin/Main/view/menuBar.html
@@ -2,7 +2,7 @@
     <div class="sidebar-nav navbar-collapse collapse" uib-collapse="$parent.isCollapsed">
         <ul class="nav" id="side-menu">
             <li class="entities-repeat" ng-repeat="(key, menu) in ::menu.children()" data-menu-id="{{ ::menu.uuid }}" compile="menu.template()">
-                <a ng-if="::menu.hasChild()" ng-click="toggleMenu(menu)" ng-class="::{'active': menu.isActive(path)}">
+                <a ng-if="::menu.hasChild()" ng-click="toggleMenu(menu)" ng-class="::{'active': menu.isChildActive(path)}">
                     <span compile="::menu.icon()"><span class="glyphicon glyphicon-list"></span></span>
                     {{ menu.title() | translate }}
                     <span class="glyphicon arrow" ng-class="::{'glyphicon-menu-down': isOpen(menu), 'glyphicon-menu-right': !isOpen(menu) }"></span>


### PR DESCRIPTION
With previous code the parent menu gets highlighted only when the first child is active and not when any of its children are active.
This change fixes that.