### PR TITLE
onSubmitSuccess default notification fixed

### DIFF
--- a/src/javascripts/ng-admin/Crud/form/FormController.js
+++ b/src/javascripts/ng-admin/Crud/form/FormController.js
@@ -73,13 +73,13 @@ export default class FormController {
                     view,
                     { $event, entity, entry, route, controller: this, form: this.form, progression, notification }
                 ))
-                .then(customHandlerReturnValue => (customHandlerReturnValue === false) ?
-                    new Promise(innerResolve => innerResolve()) :
-                    $state.go(toState, toParams())
-                )
-                .then(() => progression.done())
-                .then(() => $translate('CREATION_SUCCESS'))
-                .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
+                .then(customHandlerReturnValue => {
+                    if (customHandlerReturnValue === false) return new Promise(innerResolve => innerResolve());
+                    $translate('CREATION_SUCCESS')
+                        .then(text => notification.log(text, { addnCls: 'humane-flatty-success' }))
+                        .then(() => progression.done());
+                    return $state.go(toState, toParams())
+                })
                 .then(() => {
                     resolve();
                 })


### PR DESCRIPTION
This fixes https://github.com/marmelab/ng-admin/issues/1258.

If onSubmitSuccess returns false default notification no longer shown.
