### PR TITLE
[RFR] Debounce scroll events

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import debounce from 'lodash.debounce';
 
 const isScrollingDown = wheelEvent => {
     if (!wheelEvent) return true;
@@ -26,7 +27,7 @@ export default function maDatagridInfinitePagination($window, $document) {
             let page = 1;
             let interval;
 
-            const handler = (wheelEvent) => {
+            const handler = debounce((wheelEvent) => {
                 if (!isScrollingDown(wheelEvent) || scope.processing || !!interval) {
                     return;
                 }
@@ -56,7 +57,7 @@ export default function maDatagridInfinitePagination($window, $document) {
                         }
                     }
                 }, 100);
-            };
+            }, 500, { maxWait: 1000 });
 
             // Trigger the scroll at least once
             // This way, it loads at least one screen of data to enable further scrolling

--- a/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridInfinitePagination.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import debounce from 'lodash.debounce';
+import lodash from 'lodash';
 
 const isScrollingDown = wheelEvent => {
     if (!wheelEvent) return true;
@@ -27,7 +27,7 @@ export default function maDatagridInfinitePagination($window, $document) {
             let page = 1;
             let interval;
 
-            const handler = debounce((wheelEvent) => {
+            const handler = lodash.debounce((wheelEvent) => {
                 if (!isScrollingDown(wheelEvent) || scope.processing || !!interval) {
                     return;
                 }


### PR DESCRIPTION
When scrolling to the bottom of the page, ng-admin was sending way too many requests and didn't debounce anything.