### PR TITLE
Batch selections logic: find selected items by their identifierValue

### DIFF
--- a/src/javascripts/ng-admin/Crud/list/maDatagridController.js
+++ b/src/javascripts/ng-admin/Crud/list/maDatagridController.js
@@ -78,7 +78,7 @@ export default class DatagridController {
     toggleSelect(entry) {
         var selection = this.$scope.selection.slice();
 
-        var index = selection.indexOf(entry);
+        var index = selection.map(e => e.identifierValue).indexOf(entry.identifierValue);
 
         if (index === -1) {
             this.$scope.selection = selection.concat(entry);


### PR DESCRIPTION
There's currently a bug present in example app, generated by `make run`, and on the [demo page ](https://marmelab.com/ng-admin-demo/).
Steps to reproduce: 

1. Go to any resource page, and select several items there (for example, with id 1 and 2).
2. Go to a different page of this resource, then go back and undo selection of items you selected.
3. You will see that instead of removing items from selection, they were re-added (I selected 2 items, tried to remove them and now there's 4 items in the selection - [1, 2, 1, 2]).  This can result in admin deleting the items he unselected.

This commit fixes it, by tracking items in selection by their unique identifierValue.